### PR TITLE
Add tests rig for sendEvents

### DIFF
--- a/pkg/vsphere/adapter.go
+++ b/pkg/vsphere/adapter.go
@@ -101,6 +101,7 @@ func (a *vAdapter) sendEvents(ctx context.Context) func(moref types.ManagedObjec
 			case *types.ExtendedEvent:
 				ev.SetExtension("ExtendedEvent", e)
 			}
+
 			// TODO(mattmoor): Consider setting the subject
 
 			if err := ev.SetData(cloudevents.ApplicationXML, be); err != nil {

--- a/pkg/vsphere/adapter_test.go
+++ b/pkg/vsphere/adapter_test.go
@@ -7,25 +7,25 @@ package vsphere
 
 import (
 	"context"
+	"net/http"
+	"testing"
+	"time"
+
 	"github.com/cloudevents/sdk-go/v2/client"
 	cecontext "github.com/cloudevents/sdk-go/v2/context"
 	"github.com/vmware/govmomi/vim25/types"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
-	"net/http"
-	"testing"
-	"time"
 
 	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/event"
 	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 )
 
-
 type roundTripperTest struct {
 	statusCodes  []int
 	requestCount int
-    events []event.Event
+	events       []event.Event
 }
 
 func (r *roundTripperTest) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -43,22 +43,22 @@ type mockType struct {
 	event *types.Event
 }
 
-func (m *mockType) 	GetEvent() *types.Event{
+func (m *mockType) GetEvent() *types.Event {
 	return m.event
 }
 
 func TestSendEvents(t *testing.T) {
 	testCases := map[string]struct {
 		statusCodes []int
-		moref types.ManagedObjectReference
-		baseEvents []types.BaseEvent
-		wantEvents       []event.Event
-		result error
+		moref       types.ManagedObjectReference
+		baseEvents  []types.BaseEvent
+		wantEvents  []event.Event
+		result      error
 	}{
 		"one event, succeeds": {
 			statusCodes: []int{200},
-			moref: types.ManagedObjectReference{Value: "VirtualMachine", Type: "vm59"},
-			baseEvents: []types.BaseEvent{&mockType{event: &types.Event{CreatedTime: time.Now()}}},
+			moref:       types.ManagedObjectReference{Value: "VirtualMachine", Type: "vm59"},
+			baseEvents:  []types.BaseEvent{&mockType{event: &types.Event{CreatedTime: time.Now()}}},
 		},
 	}
 	for n, tc := range testCases {

--- a/pkg/vsphere/adapter_test.go
+++ b/pkg/vsphere/adapter_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2020 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vsphere
+
+import (
+	"context"
+	"github.com/cloudevents/sdk-go/v2/client"
+	cecontext "github.com/cloudevents/sdk-go/v2/context"
+	"github.com/vmware/govmomi/vim25/types"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/event"
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
+)
+
+
+type roundTripperTest struct {
+	statusCodes  []int
+	requestCount int
+    events []event.Event
+}
+
+func (r *roundTripperTest) RoundTrip(req *http.Request) (*http.Response, error) {
+	code := r.statusCodes[r.requestCount]
+	msg := cehttp.NewMessageFromHttpRequest(req)
+	e, err := binding.ToEvent(context.TODO(), msg)
+	if err != nil {
+		return nil, err
+	}
+	r.events = append(r.events, *e)
+	return &http.Response{StatusCode: code}, nil
+}
+
+type mockType struct {
+	event *types.Event
+}
+
+func (m *mockType) 	GetEvent() *types.Event{
+	return m.event
+}
+
+func TestSendEvents(t *testing.T) {
+	testCases := map[string]struct {
+		statusCodes []int
+		moref types.ManagedObjectReference
+		baseEvents []types.BaseEvent
+		wantEvents       []event.Event
+		result error
+	}{
+		"one event, succeeds": {
+			statusCodes: []int{200},
+			moref: types.ManagedObjectReference{Value: "VirtualMachine", Type: "vm59"},
+			baseEvents: []types.BaseEvent{&mockType{event: &types.Event{CreatedTime: time.Now()}}},
+		},
+	}
+	for n, tc := range testCases {
+		ctx := context.Background()
+		ctx = cecontext.WithTarget(ctx, "fake.example.com")
+		t.Run(n, func(t *testing.T) {
+			roundTripper := &roundTripperTest{statusCodes: tc.statusCodes}
+			opts := []cehttp.Option{
+				//cehttp.WithClient(http.Client{Timeout: time.Second}),
+				cehttp.WithRoundTripper(roundTripper),
+			}
+			p, err := cehttp.New(opts...)
+			if err != nil {
+				t.Error(err)
+			}
+			c, err := client.New(p, client.WithTimeNow(), client.WithUUIDs())
+			if err != nil {
+				t.Error(err)
+			}
+			logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
+
+			adapter := vAdapter{Logger: logger.Sugar(), CEClient: c, Source: "test-source"}
+			sendEvents := adapter.sendEvents(ctx)
+			sendResult := sendEvents(tc.moref, tc.baseEvents)
+			if sendResult != tc.result {
+				t.Errorf("Failed to send events, expected %v got %v", tc.result, sendResult)
+			}
+		})
+	}
+}

--- a/pkg/vsphere/adapter_test.go
+++ b/pkg/vsphere/adapter_test.go
@@ -7,25 +7,27 @@ package vsphere
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/cloudevents/sdk-go/v2/client"
 	cecontext "github.com/cloudevents/sdk-go/v2/context"
+	"github.com/cloudevents/sdk-go/v2/event"
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
+	"github.com/google/go-cmp/cmp"
 	"github.com/vmware/govmomi/vim25/types"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
-
-	"github.com/cloudevents/sdk-go/v2/binding"
-	"github.com/cloudevents/sdk-go/v2/event"
-	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 )
 
 type roundTripperTest struct {
 	statusCodes  []int
 	requestCount int
-	events       []event.Event
+	events       []*event.Event
 }
 
 func (r *roundTripperTest) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -35,7 +37,7 @@ func (r *roundTripperTest) RoundTrip(req *http.Request) (*http.Response, error) 
 	if err != nil {
 		return nil, err
 	}
-	r.events = append(r.events, *e)
+	r.events = append(r.events, e)
 	return &http.Response{StatusCode: code}, nil
 }
 
@@ -48,17 +50,27 @@ func (m *mockType) GetEvent() *types.Event {
 }
 
 func TestSendEvents(t *testing.T) {
+	now := time.Now()
+	baseEvent := &mockType{event: &types.Event{CreatedTime: now}}
 	testCases := map[string]struct {
 		statusCodes []int
 		moref       types.ManagedObjectReference
 		baseEvents  []types.BaseEvent
-		wantEvents  []event.Event
+		wantEvents  []*event.Event
 		result      error
 	}{
 		"one event, succeeds": {
 			statusCodes: []int{200},
 			moref:       types.ManagedObjectReference{Value: "VirtualMachine", Type: "vm59"},
-			baseEvents:  []types.BaseEvent{&mockType{event: &types.Event{CreatedTime: time.Now()}}},
+			baseEvents:  []types.BaseEvent{baseEvent},
+			wantEvents:  []*event.Event{createEvent("test-source", "mockType", "0", "eventex", nil, baseEvent, now)},
+		},
+		"one event, fails": {
+			statusCodes: []int{500},
+			moref:       types.ManagedObjectReference{Value: "VirtualMachine", Type: "vm59"},
+			baseEvents:  []types.BaseEvent{&mockType{event: &types.Event{CreatedTime: now}}},
+			wantEvents:  []*event.Event{createEvent("test-source", "mockType", "0", "eventex", nil, baseEvent, now)},
+			result:      errors.New("500: "),
 		},
 	}
 	for n, tc := range testCases {
@@ -82,9 +94,36 @@ func TestSendEvents(t *testing.T) {
 			adapter := vAdapter{Logger: logger.Sugar(), CEClient: c, Source: "test-source"}
 			sendEvents := adapter.sendEvents(ctx)
 			sendResult := sendEvents(tc.moref, tc.baseEvents)
-			if sendResult != tc.result {
-				t.Errorf("Failed to send events, expected %v got %v", tc.result, sendResult)
+			if tc.result == nil && sendResult != nil {
+				t.Error("Unexpected result from sendEvents, wanted no error got ", sendResult)
+			} else if tc.result != nil && sendResult == nil {
+				t.Error("Unexpected result from sendEvents, did not get expected error ", tc.result)
+			} else if tc.result != nil && sendResult != nil {
+				if sendResult.Error() != tc.result.Error() {
+					t.Errorf("Unexpected result from sendEvents, expected %v got %v", tc.result, sendResult)
+				}
+			}
+			for i := range tc.wantEvents {
+				if diff := cmp.Diff(tc.wantEvents[i], roundTripper.events[i]); diff != "" {
+					t.Error("unexpected diff in events", diff)
+				}
 			}
 		})
 	}
+}
+
+func createEvent(eventSource, eventType, eventID, extensionKey string, extensionValue interface{}, baseEvent interface{}, eventTime time.Time) *event.Event {
+	ev := cloudevents.NewEvent(cloudevents.VersionV1)
+
+	ev.SetType("com.vmware.vsphere." + eventType)
+	ev.SetTime(eventTime)
+	ev.SetID(eventID)
+	ev.SetSource(eventSource)
+	if extensionKey != "" {
+		ev.SetExtension(extensionKey, extensionValue)
+	}
+	if err := ev.SetData("application/xml", baseEvent); err != nil {
+		panic("Failed to SetData")
+	}
+	return &ev
 }

--- a/pkg/vsphere/adapter_test.go
+++ b/pkg/vsphere/adapter_test.go
@@ -67,7 +67,6 @@ func TestSendEvents(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			roundTripper := &roundTripperTest{statusCodes: tc.statusCodes}
 			opts := []cehttp.Option{
-				//cehttp.WithClient(http.Client{Timeout: time.Second}),
 				cehttp.WithRoundTripper(roundTripper),
 			}
 			p, err := cehttp.New(opts...)

--- a/pkg/vsphere/adapter_test.go
+++ b/pkg/vsphere/adapter_test.go
@@ -68,7 +68,7 @@ func TestSendEvents(t *testing.T) {
 		"one event, fails": {
 			statusCodes: []int{500},
 			moref:       types.ManagedObjectReference{Value: "VirtualMachine", Type: "vm59"},
-			baseEvents:  []types.BaseEvent{&mockType{event: &types.Event{CreatedTime: now}}},
+			baseEvents:  []types.BaseEvent{baseEvent},
 			wantEvents:  []*event.Event{createEvent("test-source", "mockType", "0", "eventex", nil, baseEvent, now)},
 			result:      errors.New("500: "),
 		},

--- a/vendor/go.uber.org/zap/internal/ztest/doc.go
+++ b/vendor/go.uber.org/zap/internal/ztest/doc.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package ztest provides low-level helpers for testing log output. These
+// utilities are helpful in zap's own unit tests, but any assertions using
+// them are strongly coupled to a single encoding.
+package ztest // import "go.uber.org/zap/internal/ztest"

--- a/vendor/go.uber.org/zap/internal/ztest/timeout.go
+++ b/vendor/go.uber.org/zap/internal/ztest/timeout.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ztest
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"time"
+)
+
+var _timeoutScale = 1.0
+
+// Timeout scales the provided duration by $TEST_TIMEOUT_SCALE.
+func Timeout(base time.Duration) time.Duration {
+	return time.Duration(float64(base) * _timeoutScale)
+}
+
+// Sleep scales the sleep duration by $TEST_TIMEOUT_SCALE.
+func Sleep(base time.Duration) {
+	time.Sleep(Timeout(base))
+}
+
+// Initialize checks the environment and alters the timeout scale accordingly.
+// It returns a function to undo the scaling.
+func Initialize(factor string) func() {
+	original := _timeoutScale
+	fv, err := strconv.ParseFloat(factor, 64)
+	if err != nil {
+		panic(err)
+	}
+	_timeoutScale = fv
+	return func() { _timeoutScale = original }
+}
+
+func init() {
+	if v := os.Getenv("TEST_TIMEOUT_SCALE"); v != "" {
+		Initialize(v)
+		log.Printf("Scaling timeouts by %vx.\n", _timeoutScale)
+	}
+}

--- a/vendor/go.uber.org/zap/internal/ztest/writer.go
+++ b/vendor/go.uber.org/zap/internal/ztest/writer.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ztest
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"strings"
+)
+
+// A Syncer is a spy for the Sync portion of zapcore.WriteSyncer.
+type Syncer struct {
+	err    error
+	called bool
+}
+
+// SetError sets the error that the Sync method will return.
+func (s *Syncer) SetError(err error) {
+	s.err = err
+}
+
+// Sync records that it was called, then returns the user-supplied error (if
+// any).
+func (s *Syncer) Sync() error {
+	s.called = true
+	return s.err
+}
+
+// Called reports whether the Sync method was called.
+func (s *Syncer) Called() bool {
+	return s.called
+}
+
+// A Discarder sends all writes to ioutil.Discard.
+type Discarder struct{ Syncer }
+
+// Write implements io.Writer.
+func (d *Discarder) Write(b []byte) (int, error) {
+	return ioutil.Discard.Write(b)
+}
+
+// FailWriter is a WriteSyncer that always returns an error on writes.
+type FailWriter struct{ Syncer }
+
+// Write implements io.Writer.
+func (w FailWriter) Write(b []byte) (int, error) {
+	return len(b), errors.New("failed")
+}
+
+// ShortWriter is a WriteSyncer whose write method never fails, but
+// nevertheless fails to the last byte of the input.
+type ShortWriter struct{ Syncer }
+
+// Write implements io.Writer.
+func (w ShortWriter) Write(b []byte) (int, error) {
+	return len(b) - 1, nil
+}
+
+// Buffer is an implementation of zapcore.WriteSyncer that sends all writes to
+// a bytes.Buffer. It has convenience methods to split the accumulated buffer
+// on newlines.
+type Buffer struct {
+	bytes.Buffer
+	Syncer
+}
+
+// Lines returns the current buffer contents, split on newlines.
+func (b *Buffer) Lines() []string {
+	output := strings.Split(b.String(), "\n")
+	return output[:len(output)-1]
+}
+
+// Stripped returns the current buffer contents with the last trailing newline
+// stripped.
+func (b *Buffer) Stripped() string {
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/vendor/go.uber.org/zap/zaptest/doc.go
+++ b/vendor/go.uber.org/zap/zaptest/doc.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package zaptest provides a variety of helpers for testing log output.
+package zaptest // import "go.uber.org/zap/zaptest"

--- a/vendor/go.uber.org/zap/zaptest/logger.go
+++ b/vendor/go.uber.org/zap/zaptest/logger.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+import (
+	"bytes"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// LoggerOption configures the test logger built by NewLogger.
+type LoggerOption interface {
+	applyLoggerOption(*loggerOptions)
+}
+
+type loggerOptions struct {
+	Level      zapcore.LevelEnabler
+	zapOptions []zap.Option
+}
+
+type loggerOptionFunc func(*loggerOptions)
+
+func (f loggerOptionFunc) applyLoggerOption(opts *loggerOptions) {
+	f(opts)
+}
+
+// Level controls which messages are logged by a test Logger built by
+// NewLogger.
+func Level(enab zapcore.LevelEnabler) LoggerOption {
+	return loggerOptionFunc(func(opts *loggerOptions) {
+		opts.Level = enab
+	})
+}
+
+// WrapOptions adds zap.Option's to a test Logger built by NewLogger.
+func WrapOptions(zapOpts ...zap.Option) LoggerOption {
+	return loggerOptionFunc(func(opts *loggerOptions) {
+		opts.zapOptions = zapOpts
+	})
+}
+
+// NewLogger builds a new Logger that logs all messages to the given
+// testing.TB.
+//
+//   logger := zaptest.NewLogger(t)
+//
+// Use this with a *testing.T or *testing.B to get logs which get printed only
+// if a test fails or if you ran go test -v.
+//
+// The returned logger defaults to logging debug level messages and above.
+// This may be changed by passing a zaptest.Level during construction.
+//
+//   logger := zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel))
+//
+// You may also pass zap.Option's to customize test logger.
+//
+//   logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
+func NewLogger(t TestingT, opts ...LoggerOption) *zap.Logger {
+	cfg := loggerOptions{
+		Level: zapcore.DebugLevel,
+	}
+	for _, o := range opts {
+		o.applyLoggerOption(&cfg)
+	}
+
+	writer := newTestingWriter(t)
+	zapOptions := []zap.Option{
+		// Send zap errors to the same writer and mark the test as failed if
+		// that happens.
+		zap.ErrorOutput(writer.WithMarkFailed(true)),
+	}
+	zapOptions = append(zapOptions, cfg.zapOptions...)
+
+	return zap.New(
+		zapcore.NewCore(
+			zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+			writer,
+			cfg.Level,
+		),
+		zapOptions...,
+	)
+}
+
+// testingWriter is a WriteSyncer that writes to the given testing.TB.
+type testingWriter struct {
+	t TestingT
+
+	// If true, the test will be marked as failed if this testingWriter is
+	// ever used.
+	markFailed bool
+}
+
+func newTestingWriter(t TestingT) testingWriter {
+	return testingWriter{t: t}
+}
+
+// WithMarkFailed returns a copy of this testingWriter with markFailed set to
+// the provided value.
+func (w testingWriter) WithMarkFailed(v bool) testingWriter {
+	w.markFailed = v
+	return w
+}
+
+func (w testingWriter) Write(p []byte) (n int, err error) {
+	n = len(p)
+
+	// Strip trailing newline because t.Log always adds one.
+	p = bytes.TrimRight(p, "\n")
+
+	// Note: t.Log is safe for concurrent use.
+	w.t.Logf("%s", p)
+	if w.markFailed {
+		w.t.Fail()
+	}
+
+	return n, nil
+}
+
+func (w testingWriter) Sync() error {
+	return nil
+}

--- a/vendor/go.uber.org/zap/zaptest/testingt.go
+++ b/vendor/go.uber.org/zap/zaptest/testingt.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+// TestingT is a subset of the API provided by all *testing.T and *testing.B
+// objects.
+type TestingT interface {
+	// Logs the given message without failing the test.
+	Logf(string, ...interface{})
+
+	// Logs the given message and marks the test as failed.
+	Errorf(string, ...interface{})
+
+	// Marks the test as failed.
+	Fail()
+
+	// Returns true if the test has been marked as failed.
+	Failed() bool
+
+	// Returns the name of the test.
+	Name() string
+
+	// Marks the test as failed and stops execution of that test.
+	FailNow()
+}
+
+// Note: We currently only rely on Logf. We are including Errorf and FailNow
+// in the interface in anticipation of future need since we can't extend the
+// interface without a breaking change.

--- a/vendor/go.uber.org/zap/zaptest/timeout.go
+++ b/vendor/go.uber.org/zap/zaptest/timeout.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+import (
+	"time"
+
+	"go.uber.org/zap/internal/ztest"
+)
+
+// Timeout scales the provided duration by $TEST_TIMEOUT_SCALE.
+//
+// Deprecated: This function is intended for internal testing and shouldn't be
+// used outside zap itself. It was introduced before Go supported internal
+// packages.
+func Timeout(base time.Duration) time.Duration {
+	return ztest.Timeout(base)
+}
+
+// Sleep scales the sleep duration by $TEST_TIMEOUT_SCALE.
+//
+// Deprecated: This function is intended for internal testing and shouldn't be
+// used outside zap itself. It was introduced before Go supported internal
+// packages.
+func Sleep(base time.Duration) {
+	ztest.Sleep(base)
+}

--- a/vendor/go.uber.org/zap/zaptest/writer.go
+++ b/vendor/go.uber.org/zap/zaptest/writer.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+import "go.uber.org/zap/internal/ztest"
+
+type (
+	// A Syncer is a spy for the Sync portion of zapcore.WriteSyncer.
+	Syncer = ztest.Syncer
+
+	// A Discarder sends all writes to ioutil.Discard.
+	Discarder = ztest.Discarder
+
+	// FailWriter is a WriteSyncer that always returns an error on writes.
+	FailWriter = ztest.FailWriter
+
+	// ShortWriter is a WriteSyncer whose write method never returns an error,
+	// but always reports that it wrote one byte less than the input slice's
+	// length (thus, a "short write").
+	ShortWriter = ztest.ShortWriter
+
+	// Buffer is an implementation of zapcore.WriteSyncer that sends all writes to
+	// a bytes.Buffer. It has convenience methods to split the accumulated buffer
+	// on newlines.
+	Buffer = ztest.Buffer
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -453,8 +453,10 @@ go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool
 go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
+go.uber.org/zap/internal/ztest
 go.uber.org/zap/zapcore
 # golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
+go.uber.org/zap/zaptest
 ## explicit
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/mod v0.3.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -455,8 +455,8 @@ go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/internal/ztest
 go.uber.org/zap/zapcore
-# golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 go.uber.org/zap/zaptest
+# golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 ## explicit
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/mod v0.3.0


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@vmware.com>

Just setting up the tests infra for sendEvents so we can add tests for various event types and sources, etc.