### PR TITLE
Refactor client code and update docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -112,7 +112,7 @@ accessible from your development cluster. So you can run the receive adapter
 kubernetes cluster to use for the ConfigMap-based bookmarking
 ([issue](https://github.com/vmware-tanzu-private/sources-for-knative/issues/16)).
 
-Store the credentials on the filesystem in a writable path:
+Store the credentials on the filesystem in a custom path:
 
 ```shell
 export GOVC_SECRET_PATH=var/bindings/vsphere

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/spf13/cobra v1.0.0
-	github.com/vmware/govmomi v0.22.2-0.20200505195818-967bc5808c63
+	github.com/vmware/govmomi v0.23.1
 	github.com/yudai/gotty v1.0.1
 	github.com/yudai/hcl v0.0.0-20151013225006-5fa2393b3552 // indirect
 	github.com/yudai/umutex v0.0.0-20150817080136-18216d265c6b // indirect

--- a/go.sum
+++ b/go.sum
@@ -1287,8 +1287,8 @@ github.com/vdemeester/k8s-pkg-credentialprovider v1.13.12-1/go.mod h1:Fko0rTxEtD
 github.com/vdemeester/k8s-pkg-credentialprovider v1.17.4/go.mod h1:inCTmtUdr5KJbreVojo06krnTgaeAz/Z7lynpPk/Q2c=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/vmware/govmomi v0.22.2-0.20200505195818-967bc5808c63 h1:GISHN4yim6nD40DXoSSBz67WNu7bR4XlUTIi1pRmfeY=
-github.com/vmware/govmomi v0.22.2-0.20200505195818-967bc5808c63/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.23.1 h1:vU09hxnNR/I7e+4zCJvW+5vHu5dO64Aoe2Lw7Yi/KRg=
+github.com/vmware/govmomi v0.23.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/wavesoftware/go-ensure v1.0.0/go.mod h1:K2UAFSwMTvpiRGay/M3aEYYuurcR8S4A6HkQlJPV8k4=
 github.com/xanzy/go-gitlab v0.31.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=

--- a/pkg/apis/sources/v1alpha1/vspherebinding_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/vspherebinding_lifecycle.go
@@ -83,7 +83,7 @@ func (vsb *VSphereBinding) Do(ctx context.Context, ps *duckv1.WithPod) {
 	volumeMount := corev1.VolumeMount{
 		Name:      vsphere.VolumeName,
 		ReadOnly:  true,
-		MountPath: vsphere.MountPath,
+		MountPath: vsphere.DefaultMountPath,
 	}
 
 	spec := ps.Spec.Template.Spec

--- a/pkg/apis/sources/v1alpha1/vspherebinding_lifecycle_test.go
+++ b/pkg/apis/sources/v1alpha1/vspherebinding_lifecycle_test.go
@@ -114,7 +114,7 @@ func TestVSphereBindingUndo(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
 								ReadOnly:  true,
-								MountPath: vsphere.MountPath,
+								MountPath: vsphere.DefaultMountPath,
 							}},
 						}},
 						Containers: []corev1.Container{{
@@ -136,7 +136,7 @@ func TestVSphereBindingUndo(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
 								ReadOnly:  true,
-								MountPath: vsphere.MountPath,
+								MountPath: vsphere.DefaultMountPath,
 							}},
 						}, {
 							Name:  "sidecar",
@@ -154,7 +154,7 @@ func TestVSphereBindingUndo(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
 								ReadOnly:  true,
-								MountPath: vsphere.MountPath,
+								MountPath: vsphere.DefaultMountPath,
 							}},
 						}},
 						Volumes: []corev1.Volume{{
@@ -285,7 +285,7 @@ func TestVSphereBindingDo(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
 								ReadOnly:  true,
-								MountPath: vsphere.MountPath,
+								MountPath: vsphere.DefaultMountPath,
 							}},
 						}},
 						Volumes: []corev1.Volume{{
@@ -337,7 +337,7 @@ func TestVSphereBindingDo(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
 								ReadOnly:  true,
-								MountPath: vsphere.MountPath,
+								MountPath: vsphere.DefaultMountPath,
 							}},
 						}},
 						Volumes: []corev1.Volume{{
@@ -430,7 +430,7 @@ func TestVSphereBindingDo(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
 								ReadOnly:  true,
-								MountPath: vsphere.MountPath,
+								MountPath: vsphere.DefaultMountPath,
 							}},
 						}},
 						Volumes: []corev1.Volume{{
@@ -514,7 +514,7 @@ func TestVSphereBindingDo(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
 								ReadOnly:  true,
-								MountPath: vsphere.MountPath,
+								MountPath: vsphere.DefaultMountPath,
 							}},
 						}},
 						Containers: []corev1.Container{{
@@ -556,7 +556,7 @@ func TestVSphereBindingDo(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
 								ReadOnly:  true,
-								MountPath: vsphere.MountPath,
+								MountPath: vsphere.DefaultMountPath,
 							}},
 						}, {
 							Name:  "sidecar",
@@ -594,7 +594,7 @@ func TestVSphereBindingDo(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      vsphere.VolumeName,
 								ReadOnly:  true,
-								MountPath: vsphere.MountPath,
+								MountPath: vsphere.DefaultMountPath,
 							}},
 						}},
 						Volumes: []corev1.Volume{{

--- a/pkg/vsphere/client.go
+++ b/pkg/vsphere/client.go
@@ -7,37 +7,60 @@ package vsphere
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"path/filepath"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/session/keepalive"
 	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
+	"knative.dev/pkg/logging"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
 const (
-	VolumeName = "vsphere-binding"
-	MountPath  = "/var/bindings/vsphere" // filepath.Join isn't const.
+	VolumeName        = "vsphere-binding"
+	DefaultMountPath  = "/var/bindings/vsphere" // filepath.Join isn't const.
+	keepaliveInterval = 5 * time.Minute         // vCenter APIs keep-alive
 )
 
 type EnvConfig struct {
-	Insecure bool   `envconfig:"GOVC_INSECURE" default:"false"`
-	Address  string `envconfig:"GOVC_URL" required:"true"`
+	Insecure   bool   `envconfig:"GOVC_INSECURE" default:"false"`
+	Address    string `envconfig:"GOVC_URL" required:"true"`
+	SecretPath string `envconfig:"GOVC_SECRET_PATH" default:""`
 }
 
-// ReadKey may be used to read keys from the secret.
+// ReadKey reads the key from the secret.
 func ReadKey(key string) (string, error) {
-	data, err := ioutil.ReadFile(filepath.Join(MountPath, key))
+	var env EnvConfig
+	if err := envconfig.Process("", &env); err != nil {
+		return "", err
+	}
+
+	mountPath := DefaultMountPath
+	if env.SecretPath != "" {
+		mountPath = env.SecretPath
+	}
+
+	data, err := ioutil.ReadFile(filepath.Join(mountPath, key))
 	if err != nil {
 		return "", err
 	}
 	return string(data), nil
 }
 
-func New(ctx context.Context) (*govmomi.Client, error) {
+// NewSOAPClient returns a vCenter SOAP API client with active keep-alive. Use
+// Logout() to release resources and perform a clean logout from vCenter.
+func NewSOAPClient(ctx context.Context) (*govmomi.Client, error) {
 	var env EnvConfig
 	if err := envconfig.Process("", &env); err != nil {
 		return nil, err
@@ -59,10 +82,50 @@ func New(ctx context.Context) (*govmomi.Client, error) {
 	}
 	parsedURL.User = url.UserPassword(username, password)
 
-	return govmomi.NewClient(ctx, parsedURL, env.Insecure)
+	return soapWithKeepalive(ctx, parsedURL, env.Insecure)
 }
 
-func NewREST(ctx context.Context) (*rest.Client, error) {
+func soapWithKeepalive(ctx context.Context, url *url.URL, insecure bool) (*govmomi.Client, error) {
+	soapClient := soap.NewClient(url, insecure)
+	vimClient, err := vim25.NewClient(ctx, soapClient)
+	if err != nil {
+		return nil, err
+	}
+	vimClient.RoundTripper = keepalive.NewHandlerSOAP(vimClient.RoundTripper, keepaliveInterval, soapKeepAliveHandler(ctx, vimClient))
+
+	// explicitly create session to activate keep-alive handler via Login
+	m := session.NewManager(vimClient)
+	err = m.Login(ctx, url.User)
+	if err != nil {
+		return nil, err
+	}
+
+	c := govmomi.Client{
+		Client:         vimClient,
+		SessionManager: m,
+	}
+
+	return &c, nil
+}
+
+func soapKeepAliveHandler(ctx context.Context, c *vim25.Client) func() error {
+	logger := logging.FromContext(ctx).With("rpc", "keepalive")
+
+	return func() error {
+		logger.Info("Executing SOAP keep-alive handler")
+		t, err := methods.GetCurrentTime(ctx, c)
+		if err != nil {
+			return err
+		}
+
+		logger.Infof("vCenter current time: %s", t.String())
+		return nil
+	}
+}
+
+// NewRESTClient returns a vCenter REST API client with active keep-alive. Use
+// Logout() to release resources and perform a clean logout from vCenter.
+func NewRESTClient(ctx context.Context) (*rest.Client, error) {
 	var env EnvConfig
 	if err := envconfig.Process("", &env); err != nil {
 		return nil, err
@@ -84,24 +147,35 @@ func NewREST(ctx context.Context) (*rest.Client, error) {
 	}
 	parsedURL.User = url.UserPassword(username, password)
 
-	soapclient, err := govmomi.NewClient(ctx, parsedURL, env.Insecure)
+	soapclient, err := soapWithKeepalive(ctx, parsedURL, env.Insecure)
 	if err != nil {
 		return nil, err
 	}
 
-	// For whatever reason the rest client doesn't inherit the SOAP client's auth.
 	restclient := rest.NewClient(soapclient.Client)
+	restclient.Transport = keepalive.NewHandlerREST(restclient, keepaliveInterval, restKeepAliveHandler(ctx, restclient))
+
+	// Login activates the keep-alive handler
 	if err := restclient.Login(ctx, parsedURL.User); err != nil {
 		return nil, err
 	}
 	return restclient, nil
 }
 
-func Address(ctx context.Context) (string, error) {
-	var env EnvConfig
-	if err := envconfig.Process("", &env); err != nil {
-		return "", err
-	}
+func restKeepAliveHandler(ctx context.Context, restclient *rest.Client) func() error {
+	logger := logging.FromContext(ctx).With("rpc", "keepalive")
 
-	return env.Address, nil
+	return func() error {
+		logger.Info("Executing REST keep-alive handler")
+		ctx := context.Background()
+
+		s, err := restclient.Session(ctx)
+		if err != nil {
+			return err
+		}
+		if s != nil {
+			return nil
+		}
+		return errors.New(http.StatusText(http.StatusUnauthorized))
+	}
 }

--- a/pkg/vsphere/doc.go
+++ b/pkg/vsphere/doc.go
@@ -5,7 +5,11 @@ SPDX-License-Identifier: Apache-2.0
 
 // Package vsphere holds utilities for bootstrapping a vSphere API client
 // from the metadata injected by the VSphereSource.  Within a receive adapter,
-// users can write:
+// users can create a new vSphere SOAP API client with automatic keep-alive:
 //    client, err := vsphere.NewSOAPClient(ctx)
+//
+// To properly release vSphere API resources, it is recommended to log out when the client is not needed anymore:
+//    defer client.Logout(context.Background())
+//
 // This is modeled after the Bindings pattern.
 package vsphere

--- a/pkg/vsphere/doc.go
+++ b/pkg/vsphere/doc.go
@@ -6,6 +6,6 @@ SPDX-License-Identifier: Apache-2.0
 // Package vsphere holds utilities for bootstrapping a vSphere API client
 // from the metadata injected by the VSphereSource.  Within a receive adapter,
 // users can write:
-//    client, err := vsphere.New(ctx)
+//    client, err := vsphere.NewSOAPClient(ctx)
 // This is modeled after the Bindings pattern.
 package vsphere

--- a/samples/tag-new-vms/main.go
+++ b/samples/tag-new-vms/main.go
@@ -32,8 +32,9 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	r := &receiver{manager: tags.NewManager(client)}
+	defer client.Logout(context.Background()) // using fresh context to avoid canceled err
 
+	r := &receiver{manager: tags.NewManager(client)}
 	if err := ceclient.StartReceiver(ctx, r.handle); err != nil {
 		log.Fatal(err)
 	}

--- a/samples/tag-new-vms/main.go
+++ b/samples/tag-new-vms/main.go
@@ -27,8 +27,8 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	// Instantiate a client for interacting with the vSphere APIs.
-	client, err := vsphere.NewREST(ctx)
+	// Instantiate a client for interacting with the vSphere REST APIs.
+	client, err := vsphere.NewRESTClient(ctx)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/vendor/github.com/vmware/govmomi/.mailmap
+++ b/vendor/github.com/vmware/govmomi/.mailmap
@@ -1,12 +1,16 @@
-Amanda H. L. de Andrade <amanda.andrade@serpro.gov.br> amandahla <amanda.andrade@serpro.gov.br>
 Amanda H. L. de Andrade <amanda.andrade@serpro.gov.br> Amanda Hager Lopes de Andrade Katz <amanda.katz@serpro.gov.br>
+Amanda H. L. de Andrade <amanda.andrade@serpro.gov.br> amandahla <amanda.andrade@serpro.gov.br>
 Amit Bathla <abathla@.vmware.com> <abathla@promb-1s-dhcp216.eng.vmware.com>
-Andrew Kutz <akutz@vmware.com> akutz <akutz@vmware.com>
 Andrew Kutz <akutz@vmware.com> <sakutz@gmail.com>
 Andrew Kutz <akutz@vmware.com> Andrew Kutz <101085+akutz@users.noreply.github.com>
+Andrew Kutz <akutz@vmware.com> akutz <akutz@vmware.com>
+Anfernee Yongkun Gui <agui@vmware.com> <anfernee.gui@gmail.com>
+Anfernee Yongkun Gui <agui@vmware.com> Yongkun Anfernee Gui <agui@vmware.com>
+Anna Carrigan <anna.carrigan@hpe.com> Anna <anna.carrigan@outlook.com>
+Balu Dontu <bdontu@vmware.com> BaluDontu <bdontu@vmware.com>
 Bruce Downs <bruceadowns@gmail.com> <bdowns@vmware.com>
-Bruce Downs <bruceadowns@gmail.com> <bruce.downs@jivesoftware.com>
 Bruce Downs <bruceadowns@gmail.com> <bruce.downs@autodesk.com>
+Bruce Downs <bruceadowns@gmail.com> <bruce.downs@jivesoftware.com>
 Clint Greenwood <cgreenwood@vmware.com> <clint.greenwood@gmail.com>
 Cédric Blomart <cblomart@gmail.com> <cedric.blomart@minfin.fed.be>
 Cédric Blomart <cblomart@gmail.com> cedric <cblomart@gmail.com>
@@ -14,17 +18,18 @@ David Stark <dave@davidstark.name> <david.stark@bskyb.com>
 Eric Gray <egray@vmware.com> <ericgray@users.noreply.github.com>
 Eric Yutao <eric.yutao@gmail.com> eric <eric.yutao@gmail.com>
 Fabio Rapposelli <fabio@vmware.com> <fabio@rapposelli.org>
+Faiyaz Ahmed <faiyaza@vmware.com> Faiyaz Ahmed <ahmedf@vmware.com>
+Faiyaz Ahmed <faiyaza@vmware.com> Faiyaz Ahmed <faiyaza@gmail.com>
+Faiyaz Ahmed <faiyaza@vmware.com> Faiyaz Ahmed <fdawg4l@users.noreply.github.com>
 Henrik Hodne <henrik@travis-ci.com> <henrik@hodne.io>
 Jeremy Canady <jcanady@jackhenry.com> <jcanady@gmail.com>
+Jiatong Wang <wjiatong@vmware.com> jiatongw <wjiatong@vmware.com>
+Lintong Jiang <lintongj@vmware.com> lintongj <55512168+lintongj@users.noreply.github.com>
 Pieter Noordhuis <pnoordhuis@vmware.com> <pcnoordhuis@gmail.com>
 Takaaki Furukawa <takaaki.frkw@gmail.com> takaaki.furukawa <takaaki.furukawa@mail.rakuten.com>
 Takaaki Furukawa <takaaki.frkw@gmail.com> tkak <takaaki.frkw@gmail.com>
-Vadim Egorov <vegorov@vmware.com> <egorovv@gmail.com>
-Anfernee Yongkun Gui <agui@vmware.com> <anfernee.gui@gmail.com>
-Anfernee Yongkun Gui <agui@vmware.com> Yongkun Anfernee Gui <agui@vmware.com>
-Zach Tucker <ztucker@vmware.com> <jzt@users.noreply.github.com>
-Zee Yang <zeey@vmware.com> <zee.yang@gmail.com>
-Jiatong Wang <wjiatong@vmware.com> jiatongw <wjiatong@vmware.com>
 Uwe Bessle <Uwe.Bessle@iteratec.de> Uwe Bessle <u.bessle.extern@eos-ts.com>
 Uwe Bessle <Uwe.Bessle@iteratec.de> Uwe Bessle <uwe.bessle@web.de>
-Lintong Jiang <lintongj@vmware.com> lintongj <55512168+lintongj@users.noreply.github.com>
+Vadim Egorov <vegorov@vmware.com> <egorovv@gmail.com>
+Zach Tucker <ztucker@vmware.com> <jzt@users.noreply.github.com>
+Zee Yang <zeey@vmware.com> <zee.yang@gmail.com>

--- a/vendor/github.com/vmware/govmomi/.travis.yml
+++ b/vendor/github.com/vmware/govmomi/.travis.yml
@@ -12,7 +12,7 @@ services:       false
 
 # Set the version of Go.
 language:       go
-go:             1.13
+go:             1.14
 
 # Always set the project's Go import path to ensure that forked
 # builds get cloned to the correct location.

--- a/vendor/github.com/vmware/govmomi/CHANGELOG.md
+++ b/vendor/github.com/vmware/govmomi/CHANGELOG.md
@@ -1,6 +1,24 @@
 # changelog
 
-### 0.22.2 (2020-02-04)
+### 0.23.0 (2020-06-11)
+
+* Finder: support DistributedVirtualSwitch traversal
+
+* Update to vSphere 7 APIs
+
+* Avoid possible nil pointer dereference in guest TransferURL
+
+* Refactor govc session persistence into session/cache package
+
+* Add SetTaskState SetTaskDescription UpdateProgress to object package
+
+* Add Content Library subscriptions support
+
+* Add Content Library item copy support
+
+* Sync vim25/xml with golang 1.13 encoding/xml
+
+* vapi: Add cluster modules client and simulator
 
 * Expose soap client default transport
 

--- a/vendor/github.com/vmware/govmomi/CONTRIBUTORS
+++ b/vendor/github.com/vmware/govmomi/CONTRIBUTORS
@@ -6,6 +6,7 @@
 Abhijeet Kasurde <akasurde@redhat.com>
 abrarshivani <abrarshivani@users.noreply.github.com>
 Adam Shannon <adamkshannon@gmail.com>
+Al Biheiri <abiheiri@apple.com>
 Alessandro Cortiana <alessandro.cortiana@gmail.com>
 Alex Bozhenko <alexbozhenko@fb.com>
 Alex Ellis (VMware) <alexellis2@gmail.com>
@@ -21,6 +22,8 @@ Andrey Klimentyev <andrey.klimentyev@flant.com>
 Anfernee Yongkun Gui <agui@vmware.com>
 angystardust <angystardust@users.noreply.github.com>
 aniketGslab <aniket.shinde@gslab.com>
+Ankit Vaidya <vaidyaa@vmware.com>
+Anna Carrigan <anna.carrigan@hpe.com>
 Arran Walker <arran.walker@zopa.com>
 Artem Anisimov <aanisimov@inbox.ru>
 Aryeh Weinreb <aryehweinreb@gmail.com>
@@ -28,26 +31,33 @@ Austin Parker <aparker@apprenda.com>
 Balu Dontu <bdontu@vmware.com>
 bastienbc <bastien.barbe.creuly@gmail.com>
 Ben Corrie <bcorrie@vmware.com>
+Benjamin Davini <davinib@vmware.com>
 Benjamin Peterson <benjamin@python.org>
 Bob Killen <killen.bob@gmail.com>
 Brad Fitzpatrick <bradfitz@golang.org>
 Bruce Downs <bruceadowns@gmail.com>
 Cédric Blomart <cblomart@gmail.com>
+Cheng Cheng <chengch@vmware.com>
+Chethan Venkatesh <chethanv@vmware.com>
 Chris Marchesi <chrism@vancluevertech.com>
 Christian Höltje <docwhat@gerf.org>
 Clint Greenwood <cgreenwood@vmware.com>
 CuiHaozhi <cuihaozhi@chinacloud.com.cn>
 Daniel Mueller <deso@posteo.net>
+Dan Ilan <danilan@google.com>
 Danny Lockard <danny.lockard@banno.com>
 Dave Gress <gressd@vmware.com>
 Dave Smith-Uchida <dsmithuchida@vmware.com>
 Dave Tucker <dave@dtucker.co.uk>
 Davide Agnello <dagnello@hp.com>
+David Gress <gressd@vmware.com>
 David Stark <dave@davidstark.name>
 Davinder Kumar <davinderk@vmware.com>
+demarey <christophe.demarey@inria.fr>
 dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 Deric Crago <deric.crago@gmail.com>
 Divyen Patel <divyenp@vmware.com>
+Dnyanesh Gate <dnyanesh.gate@druva.com>
 Doug MacEachern <dougm@vmware.com>
 Eloy Coto <eloy.coto@gmail.com>
 Eric Edens <ericedens@google.com>
@@ -56,8 +66,10 @@ Eric Gray <egray@vmware.com>
 Eric Yutao <eric.yutao@gmail.com>
 Erik Hollensbe <github@hollensbe.org>
 Ethan Kaley <ethan.kaley@emc.com>
+Evan Chu <echu@vmware.com>
 Fabio Rapposelli <fabio@vmware.com>
-Faiyaz Ahmed <ahmedf@vmware.com>
+Faiyaz Ahmed <faiyaza@vmware.com>
+Federico Pellegatta <12744504+federico-pellegatta@users.noreply.github.com>
 forkbomber <forkbomber@users.noreply.github.com>
 François Rigault <rigault.francois@gmail.com>
 freebsdly <qinhuajun@outlook.com>
@@ -86,6 +98,7 @@ kayrus <kay.diam@gmail.com>
 Kevin George <georgek@vmware.com>
 leslie-qiwa <leslie.qiwa@gmail.com>
 Lintong Jiang <lintongj@vmware.com>
+Liping Xue <lipingx@vmware.com>
 Louie Jiang <jiangl@vmware.com>
 Luther Monson <luther.monson@gmail.com>
 maplain <fangyuanl@vmware.com>
@@ -97,6 +110,7 @@ Mario Trangoni <mjtrangoni@gmail.com>
 Mark Peek <markpeek@vmware.com>
 Matt Clay <matt@mystile.com>
 Matthew Cosgrove <matthew.cosgrove@dell.com>
+Matt Moore <mattmoor@vmware.com>
 Matt Moriarity <matt@mattmoriarity.com>
 Mevan Samaratunga <mevansam@gmail.com>
 Michal Jankowski <mjankowski@vmware.com>
@@ -109,15 +123,20 @@ Pieter Noordhuis <pnoordhuis@vmware.com>
 prydin <prydin@vmware.com>
 rHermes <teodor_spaeren@riseup.net>
 Rowan Jacobs <rojacobs@pivotal.io>
+rsikdar <rsikdar@berkeley.edu>
 runner.mei <runner.mei@gmail.com>
+Sandeep Pissay Srinivasa Rao <ssrinivas@vmware.com>
 S.Çağlar Onur <conur@vmware.com>
 Sergey Ignatov <sergey.ignatov@jetbrains.com>
 serokles <timbo.alexander@gmail.com>
+Shalini Bhaskara <sbhaskara@vmware.com>
 Shawn Neal <sneal@sneal.net>
+shylasrinivas <sshyla@vmware.com>
 sky-joker <sky.jokerxx@gmail.com>
 Sten Feldman <exile@chamber.ee>
 Stepan Mazurov <smazurov@gmail.com>
 Steve Purcell <steve@sanityinc.com>
+SUMIT AGRAWAL <asumit@vmware.com>
 Takaaki Furukawa <takaaki.frkw@gmail.com>
 Tamas Eger <tamas.eger@bitrise.io>
 tanishi <tanishi503@gmail.com>
@@ -128,13 +147,19 @@ Tim McNamara <tim.mcnamara@canonical.com>
 Tjeu Kayim <15987676+TjeuKayim@users.noreply.github.com>
 Toomas Pelberg <toomas.pelberg@playtech.com>
 Trevor Dawe <trevor.dawe@gmail.com>
+tshihad <tshihad9@gmail.com>
 Uwe Bessle <Uwe.Bessle@iteratec.de>
 Vadim Egorov <vegorov@vmware.com>
 Vikram Krishnamurthy <vikramkrishnamu@vmware.com>
+volanja <volaaanja@gmail.com>
 Volodymyr Bobyr <pupsua@gmail.com>
+Waldek Maleska <w.maleska@gmail.com>
 William Lam <info.virtuallyghetto@gmail.com>
 Witold Krecicki <wpk@culm.net>
+xing-yang <xingyang105@gmail.com>
+yangxi <yangxi@vmware.com>
 Yang Yang <yangy@vmware.com>
+Yann Hodique <yhodique@google.com>
 ykakarap <yuva2811@gmail.com>
 Yuya Kusakabe <yuya.kusakabe@gmail.com>
 Zacharias Taubert <zacharias.taubert@gmail.com>

--- a/vendor/github.com/vmware/govmomi/README.md
+++ b/vendor/github.com/vmware/govmomi/README.md
@@ -15,9 +15,9 @@ In addition to the vSphere API client, this repository includes:
 
 ## Compatibility
 
-This library is built for and tested against ESXi and vCenter 6.0, 6.5 and 6.7.
+This library is built for and tested against ESXi and vCenter 6.5, 6.7 and 7.0.
 
-It may work with versions 5.5 and 5.1, but neither are officially supported.
+It may work with versions 5.1, 5.5 and 6.0, but neither are officially supported.
 
 ## Documentation
 
@@ -28,7 +28,7 @@ The code in the `govmomi` package is a wrapper for the code that is generated fr
 It primarily provides convenience functions for working with the vSphere API.
 See [godoc.org][godoc] for documentation.
 
-[apiref]:https://code.vmware.com/apis/196/vsphere
+[apiref]:https://code.vmware.com/apis/968/vsphere
 [godoc]:http://godoc.org/github.com/vmware/govmomi
 
 ## Installation
@@ -85,12 +85,24 @@ Refer to the [CHANGELOG](CHANGELOG.md) for version to version changes.
 
 * [Juju](https://github.com/juju/juju)
 
+* [vSphere 7.0](https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-vcenter-server-7-vsphere-with-kubernetes-release-notes.html)
+
+* [OPS](https://github.com/nanovms/ops)
+
 ## Related projects
 
 * [rbvmomi](https://github.com/vmware/rbvmomi)
 
 * [pyvmomi](https://github.com/vmware/pyvmomi)
 
+* [go-vmware-nsxt](https://github.com/vmware/go-vmware-nsxt)
+
 ## License
 
 govmomi is available under the [Apache 2 license](LICENSE.txt).
+
+## Name
+
+Pronounced "go-v-mom-ie"
+
+Follows pyvmomi and rbvmomi: language prefix + the vSphere acronym "VM Object Management Infrastructure".

--- a/vendor/github.com/vmware/govmomi/govc/CHANGELOG.md
+++ b/vendor/github.com/vmware/govmomi/govc/CHANGELOG.md
@@ -1,5 +1,51 @@
 # changelog
 
+### 0.23.0 (2020-06-11)
+
+* Add vcsa.log.forwarding.info command
+
+* ipath search flag does not require a Datacenter
+
+* Support find with -customValue filter
+
+* Support VirtualApp with -pool flag
+
+* Add '-version' flag to datastore.create command
+
+* Add session.login '-X' flag
+
+* Fix host.info CPU usage
+
+* Add session.ls '-r' flag
+
+* Support REST session caching
+
+* Add vm.change '-uuid' flag
+
+* Enable library.checkout and library.checkin by default (7.0 feature)
+
+* Avoid truncation in object.collect
+
+* Add vm.change '-memory-pin' flag
+
+* Support nested groups in sso.group.update
+
+* Add library.publish command
+
+* Add library.subscriber commands: create, info, ls, rm
+
+* Add cluster.group.ls -l flag
+
+* Add library.cp command
+
+* Add library.clone -ovf flag
+
+* Add object.collect -o flag
+
+* Add find '-l' flag
+
+* Add '-xml' output flag
+
 ### 0.22.1 (2020-01-13)
 
 * Fix session.login using HoK token with delegated Bearer identity token against 6.7 U3b+

--- a/vendor/github.com/vmware/govmomi/govc/README.md
+++ b/vendor/github.com/vmware/govmomi/govc/README.md
@@ -146,7 +146,7 @@ output in `~/.govmomi/debug/<run timestamp>`. In that directory will be four (4)
 ```
 
 In that filename the `0001` represents the an incremented call order and will increment for each time the SOAP client
-makes an API call. 
+makes an API call.
 
 To configure the debug output you can use two environment variables.
 * `GOVC_DEBUG_PATH`: defaults to ~/.govmomi/debug
@@ -232,3 +232,7 @@ version from within a script, for example:
 ## License
 
 govc is available under the [Apache 2 license](../LICENSE).
+
+## Name
+
+Pronounced "go-v-c", short for "Go(lang) vCenter CLI".

--- a/vendor/github.com/vmware/govmomi/govc/flags/client.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/client.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/session/cache"
+	"github.com/vmware/govmomi/session/keepalive"
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -390,6 +391,17 @@ func (flag *ClientFlag) RestClient() (*rest.Client, error) {
 
 	flag.restClient = c
 	return flag.restClient, nil
+}
+
+func (flag *ClientFlag) KeepAlive(client cache.Client) {
+	switch c := client.(type) {
+	case *vim25.Client:
+		keepalive.NewHandlerSOAP(c, 0, nil).Start()
+	case *rest.Client:
+		keepalive.NewHandlerREST(c, 0, nil).Start()
+	default:
+		panic(fmt.Sprintf("unsupported client type=%T", client))
+	}
 }
 
 func (flag *ClientFlag) Logout(ctx context.Context) error {

--- a/vendor/github.com/vmware/govmomi/govc/flags/version.go
+++ b/vendor/github.com/vmware/govmomi/govc/flags/version.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 )
 
-const Version = "0.22.1"
+const Version = "0.23.0"
 
 var GitVersion string
 

--- a/vendor/github.com/vmware/govmomi/govc/host/esxcli/esxcli.go
+++ b/vendor/github.com/vmware/govmomi/govc/host/esxcli/esxcli.go
@@ -59,7 +59,8 @@ Examples:
   govc host.esxcli network ip connection list
   govc host.esxcli system settings advanced set -o /Net/GuestIPHack -i 1
   govc host.esxcli network firewall ruleset set -r remoteSerialPort -e true
-  govc host.esxcli network firewall set -e false`
+  govc host.esxcli network firewall set -e false
+  govc host.esxcli hardware platform get`
 }
 
 func (cmd *esxcli) Process(ctx context.Context) error {

--- a/vendor/github.com/vmware/govmomi/govc/importx/ovf.go
+++ b/vendor/github.com/vmware/govmomi/govc/importx/ovf.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/govc/cli"
 	"github.com/vmware/govmomi/govc/flags"
 	"github.com/vmware/govmomi/nfc"
@@ -163,34 +164,42 @@ func (cmd *ovfx) Map(op []Property) (p []types.KeyValue) {
 	return
 }
 
-func (cmd *ovfx) NetworkMap(e *ovf.Envelope) (p []types.OvfNetworkMapping) {
+func (cmd *ovfx) NetworkMap(e *ovf.Envelope) ([]types.OvfNetworkMapping, error) {
 	ctx := context.TODO()
 	finder, err := cmd.DatastoreFlag.Finder()
 	if err != nil {
-		return
+		return nil, err
 	}
 
-	networks := map[string]string{}
-
-	if e.Network != nil {
-		for _, net := range e.Network.Networks {
-			networks[net.Name] = net.Name
+	var nmap []types.OvfNetworkMapping
+	for _, m := range cmd.Options.NetworkMapping {
+		if m.Network == "" {
+			continue // Not set, let vSphere choose the default network
 		}
-	}
 
-	for _, net := range cmd.Options.NetworkMapping {
-		networks[net.Name] = net.Network
-	}
+		var ref types.ManagedObjectReference
 
-	for src, dst := range networks {
-		if net, err := finder.Network(ctx, dst); err == nil {
-			p = append(p, types.OvfNetworkMapping{
-				Name:    src,
-				Network: net.Reference(),
-			})
+		net, err := finder.Network(ctx, m.Network)
+		if err != nil {
+			switch err.(type) {
+			case *find.NotFoundError:
+				if !ref.FromString(m.Network) {
+					return nil, err
+				} // else this is a raw MO ref
+			default:
+				return nil, err
+			}
+		} else {
+			ref = net.Reference()
 		}
+
+		nmap = append(nmap, types.OvfNetworkMapping{
+			Name:    m.Name,
+			Network: ref,
+		})
 	}
-	return
+
+	return nmap, err
 }
 
 func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
@@ -224,6 +233,11 @@ func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
 		name = cmd.Name
 	}
 
+	nmap, err := cmd.NetworkMap(e)
+	if err != nil {
+		return nil, err
+	}
+
 	cisp := types.OvfCreateImportSpecParams{
 		DiskProvisioning:   cmd.Options.DiskProvisioning,
 		EntityName:         name,
@@ -233,7 +247,7 @@ func (cmd *ovfx) Import(fpath string) (*types.ManagedObjectReference, error) {
 			DeploymentOption: cmd.Options.Deployment,
 			Locale:           "US"},
 		PropertyMapping: cmd.Map(cmd.Options.PropertyMapping),
-		NetworkMapping:  cmd.NetworkMap(e),
+		NetworkMapping:  nmap,
 	}
 
 	host, err := cmd.HostSystemIfSpecified()

--- a/vendor/github.com/vmware/govmomi/govc/library/deploy.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/deploy.go
@@ -99,10 +99,17 @@ func (cmd *deploy) Run(ctx context.Context, f *flag.FlagSet) error {
 		name = *cmd.Options.Name
 	}
 
+	vc, err := cmd.DatastoreFlag.Client()
+	if err != nil {
+		return err
+	}
+	cmd.KeepAlive(vc)
+
 	c, err := cmd.DatastoreFlag.RestClient()
 	if err != nil {
 		return err
 	}
+	cmd.KeepAlive(c)
 
 	m := vcenter.NewManager(c)
 

--- a/vendor/github.com/vmware/govmomi/govc/library/export.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/export.go
@@ -138,9 +138,7 @@ func (cmd *export) Run(ctx context.Context, f *flag.FlagSet) error {
 
 	download := func(src *url.URL, name string) error {
 		p := soap.DefaultDownload
-		p.Headers = map[string]string{
-			"vmware-api-session-id": c.SessionID,
-		}
+
 		if isStdout {
 			s, _, err := c.Download(ctx, src, &p)
 			if err != nil {

--- a/vendor/github.com/vmware/govmomi/govc/library/import.go
+++ b/vendor/github.com/vmware/govmomi/govc/library/import.go
@@ -144,6 +144,7 @@ func (cmd *item) Run(ctx context.Context, f *flag.FlagSet) error {
 	if err != nil {
 		return err
 	}
+	cmd.KeepAlive(c)
 
 	m := library.NewManager(c)
 	res, err := flags.ContentLibraryResult(ctx, c, "", f.Arg(0))
@@ -201,9 +202,6 @@ func (cmd *item) Run(ctx context.Context, f *flag.FlagSet) error {
 		}
 
 		p := soap.DefaultUpload
-		p.Headers = map[string]string{
-			"vmware-api-session-id": session,
-		}
 		p.ContentLength = size
 		u, err := url.Parse(update.UploadEndpoint.URI)
 		if err != nil {

--- a/vendor/github.com/vmware/govmomi/govc/main.go
+++ b/vendor/github.com/vmware/govmomi/govc/main.go
@@ -84,6 +84,7 @@ import (
 	_ "github.com/vmware/govmomi/govc/tags/category"
 	_ "github.com/vmware/govmomi/govc/task"
 	_ "github.com/vmware/govmomi/govc/vapp"
+	_ "github.com/vmware/govmomi/govc/vcsa/log"
 	_ "github.com/vmware/govmomi/govc/version"
 	_ "github.com/vmware/govmomi/govc/vm"
 	_ "github.com/vmware/govmomi/govc/vm/disk"

--- a/vendor/github.com/vmware/govmomi/govc/object/save.go
+++ b/vendor/github.com/vmware/govmomi/govc/object/save.go
@@ -84,6 +84,7 @@ Examples:
 
 func (cmd *save) save(content []types.ObjectContent) error {
 	for _, x := range content {
+		x.MissingSet = nil // drop any NoPermission faults
 		cmd.summary[x.Obj.Type]++
 		if cmd.verbose {
 			fmt.Printf("Saving %s...", x.Obj)

--- a/vendor/github.com/vmware/govmomi/govc/session/login.go
+++ b/vendor/github.com/vmware/govmomi/govc/session/login.go
@@ -106,7 +106,8 @@ The session.login command can be used to:
 - Send an authenticated raw HTTP request
 
 Examples:
-  govc session.login -u root:password@host
+  govc session.login -u root:password@host # Creates a cached session in ~/.govmomi/sessions
+  govc session.ls -u root@host # Use the cached session with another command
   ticket=$(govc session.login -u root@host -clone)
   govc session.login -u root@host -ticket $ticket
   govc session.login -u host -extension com.vmware.vsan.health -cert rui.crt -key rui.key
@@ -263,9 +264,9 @@ func (cmd *login) setCookie(ctx context.Context, c *vim25.Client) error {
 
 func (cmd *login) setRestCookie(ctx context.Context, c *rest.Client) error {
 	if cmd.cookie == "" {
-		cmd.cookie = c.SessionID
+		cmd.cookie = c.SessionID()
 	} else {
-		c.SessionID = cmd.cookie
+		c.SessionID(cmd.cookie)
 
 		// Check the session is still valid
 		s, err := c.Session(ctx)

--- a/vendor/github.com/vmware/govmomi/govc/session/ls.go
+++ b/vendor/github.com/vmware/govmomi/govc/session/ls.go
@@ -140,7 +140,7 @@ func (cmd *ls) Run(ctx context.Context, f *flag.FlagSet) error {
 				return err
 			}
 			m.SessionList = append(m.SessionList, types.UserSession{
-				Key:            rc.SessionID,
+				Key:            rc.SessionID(),
 				UserName:       rs.User + " (REST)",
 				LoginTime:      rs.Created,
 				LastActiveTime: rs.LastAccessed,

--- a/vendor/github.com/vmware/govmomi/govc/usage.sh
+++ b/vendor/github.com/vmware/govmomi/govc/usage.sh
@@ -9,6 +9,7 @@ common_opts=$(cat <<EOF
   -debug=false              Store debug logs [GOVC_DEBUG]
   -dump=false               Enable output dump
   -json=false               Enable JSON output
+  -xml=false                Enable XML output
   -k=false                  Skip verification of server certificate [GOVC_INSECURE]
   -key=                     Private key [GOVC_PRIVATE_KEY]
   -persist-session=true     Persist session to disk [GOVC_PERSIST_SESSION]

--- a/vendor/github.com/vmware/govmomi/govc/vcsa/log/forwarding.go
+++ b/vendor/github.com/vmware/govmomi/govc/vcsa/log/forwarding.go
@@ -1,0 +1,93 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/govc/cli"
+	"github.com/vmware/govmomi/govc/flags"
+	vlogging "github.com/vmware/govmomi/vapi/appliance/logging"
+)
+
+type info struct {
+	*flags.ClientFlag
+	*flags.OutputFlag
+}
+
+func init() {
+	cli.Register("vcsa.log.forwarding.info", &info{})
+}
+
+func (cmd *info) Register(ctx context.Context, f *flag.FlagSet) {
+	cmd.ClientFlag, ctx = flags.NewClientFlag(ctx)
+	cmd.ClientFlag.Register(ctx, f)
+
+	cmd.OutputFlag, ctx = flags.NewOutputFlag(ctx)
+	cmd.OutputFlag.Register(ctx, f)
+}
+
+func (cmd *info) Process(ctx context.Context) error {
+	if err := cmd.ClientFlag.Process(ctx); err != nil {
+		return err
+	}
+	if err := cmd.OutputFlag.Process(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *info) Description() string {
+	return `Retrieve the VC Appliance log forwarding configuration
+
+Examples:
+  govc vcsa.log.forwarding.info`
+}
+
+func (cmd *info) Run(ctx context.Context, f *flag.FlagSet) error {
+	c, err := cmd.RestClient()
+	if err != nil {
+		return err
+	}
+
+	fwd := vlogging.NewManager(c)
+
+	res, err := fwd.Forwarding(ctx)
+	if err != nil {
+		return nil
+	}
+
+	return cmd.WriteResult(forwardingConfigResult(res))
+}
+
+type forwardingConfigResult []vlogging.Forwarding
+
+func (res forwardingConfigResult) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	for _, c := range res {
+		fmt.Fprintf(tw, "Hostname:\t%s\n", c.Hostname)
+		fmt.Fprintf(tw, "Port:\t%d\n", c.Port)
+		fmt.Fprintf(tw, "Protocol:\t%s\n", c.Protocol)
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/govc/vm/clone.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/clone.go
@@ -127,7 +127,8 @@ Examples:
   govc vm.clone -vm template-vm -cluster cluster1 new-vm # use compute cluster placement
   govc vm.clone -vm template-vm -datastore-cluster dscluster new-vm # use datastore cluster placement
   govc vm.clone -vm template-vm -snapshot $(govc snapshot.tree -vm template-vm -C) new-vm
-  govc vm.clone -vm template-vm -template new-template # clone a VM template`
+  govc vm.clone -vm template-vm -template new-template # clone a VM template
+  govc vm.clone -vm=/ClusterName/vm/FolderName/VM_templateName -on=true -host=myesxi01 -ds=datastore01 myVM_name`
 }
 
 func (cmd *clone) Process(ctx context.Context) error {

--- a/vendor/github.com/vmware/govmomi/govc/vm/create.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/create.go
@@ -40,6 +40,7 @@ var hardwareVersions = []struct {
 	{"6.0", "vmx-11"},
 	{"6.5", "vmx-13"},
 	{"6.7", "vmx-14"},
+	{"7.0", "vmx-17"},
 }
 
 type create struct {

--- a/vendor/github.com/vmware/govmomi/govc/vm/guest/run.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/guest/run.go
@@ -64,7 +64,8 @@ Examples:
   cal | govc guest.run -vm $name -d - cat
   govc guest.run -vm $name -d "hello $USER" cat
   govc guest.run -vm $name curl -s :invalid: || echo $? # exit code 6
-  govc guest.run -vm $name -e FOO=bar -e BIZ=baz -C /tmp env`
+  govc guest.run -vm $name -e FOO=bar -e BIZ=baz -C /tmp env
+  govc guest.run -l root:'mypassword' -vm my_vm_hostname "ntpdate -u pool.ntp.org"`
 }
 
 func (cmd *run) Run(ctx context.Context, f *flag.FlagSet) error {

--- a/vendor/github.com/vmware/govmomi/govc/vm/network/add.go
+++ b/vendor/github.com/vmware/govmomi/govc/vm/network/add.go
@@ -47,6 +47,7 @@ func (cmd *add) Description() string {
 
 Examples:
   govc vm.network.add -vm $vm -net "VM Network" -net.adapter e1000e
+  govc vm.network.add -vm $vm -net SwitchName/PortgroupName
   govc device.info -vm $vm ethernet-*`
 }
 

--- a/vendor/github.com/vmware/govmomi/object/virtual_machine.go
+++ b/vendor/github.com/vmware/govmomi/object/virtual_machine.go
@@ -855,8 +855,10 @@ func (v VirtualMachine) UUID(ctx context.Context) string {
 	if err != nil {
 		return ""
 	}
-
-	return o.Config.Uuid
+	if o.Config != nil {
+		return o.Config.Uuid
+	}
+	return ""
 }
 
 func (v VirtualMachine) QueryChangedDiskAreas(ctx context.Context, baseSnapshot, curSnapshot *types.ManagedObjectReference, disk *types.VirtualDisk, offset int64) (types.DiskChangeInfo, error) {

--- a/vendor/github.com/vmware/govmomi/pbm/pbm_util.go
+++ b/vendor/github.com/vmware/govmomi/pbm/pbm_util.go
@@ -27,6 +27,7 @@ import (
 // A struct to capture pbm create spec details.
 type CapabilityProfileCreateSpec struct {
 	Name           string
+	SubProfileName string
 	Description    string
 	Category       string
 	CapabilityList []Capability
@@ -64,6 +65,7 @@ func CreateCapabilityProfileSpec(pbmCreateSpec CapabilityProfileCreateSpec) (*ty
 			SubProfiles: []types.PbmCapabilitySubProfile{
 				types.PbmCapabilitySubProfile{
 					Capability: capabilities,
+					Name:       pbmCreateSpec.SubProfileName,
 				},
 			},
 		},

--- a/vendor/github.com/vmware/govmomi/pbm/simulator/simulator.go
+++ b/vendor/github.com/vmware/govmomi/pbm/simulator/simulator.go
@@ -118,6 +118,13 @@ func (m *ProfileManager) PbmQueryProfile(req *types.PbmQueryProfile) soap.HasFau
 	return body
 }
 
+func (m *ProfileManager) PbmQueryAssociatedProfile(req *types.PbmQueryAssociatedProfile) soap.HasFault {
+	body := new(methods.PbmQueryAssociatedProfileBody)
+	body.Res = new(types.PbmQueryAssociatedProfileResponse)
+
+	return body
+}
+
 func (m *ProfileManager) PbmRetrieveContent(req *types.PbmRetrieveContent) soap.HasFault {
 	body := new(methods.PbmRetrieveContentBody)
 	if len(req.ProfileIds) == 0 {

--- a/vendor/github.com/vmware/govmomi/session/cache/session.go
+++ b/vendor/github.com/vmware/govmomi/session/cache/session.go
@@ -325,18 +325,16 @@ func (s *Session) Login(ctx context.Context, c Client, config func(*soap.Client)
 		*client = *vc
 		c = client
 	case *rest.Client:
-		vc := &vim25.Client{Client: sc}
-		rc := rest.NewClient(vc)
+		client.Client = sc.NewServiceClient(rest.Path, "")
 
 		login := s.loginREST
 		if s.LoginREST != nil {
 			login = s.LoginREST
 		}
-		if err = login(ctx, rc); err != nil {
+		if err = login(ctx, client); err != nil {
 			return err
 		}
 
-		*client = *rc
 		c = client
 	default:
 		panic(fmt.Sprintf("unsupported client type=%T", client))

--- a/vendor/github.com/vmware/govmomi/session/keep_alive.go
+++ b/vendor/github.com/vmware/govmomi/session/keep_alive.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015,2019 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015-2020 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,115 +17,24 @@ limitations under the License.
 package session
 
 import (
-	"context"
-	"sync"
 	"time"
 
-	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/session/keepalive"
 	"github.com/vmware/govmomi/vim25/soap"
 )
 
-type keepAlive struct {
-	sync.Mutex
-
-	roundTripper    soap.RoundTripper
-	idleTime        time.Duration
-	notifyRequest   chan struct{}
-	notifyStop      chan struct{}
-	notifyWaitGroup sync.WaitGroup
-
-	// keepAlive executes a request in the background with the purpose of
-	// keeping the session active. The response for this request is discarded.
-	keepAlive func(soap.RoundTripper) error
-}
-
-func defaultKeepAlive(roundTripper soap.RoundTripper) error {
-	_, err := methods.GetCurrentTime(context.Background(), roundTripper)
-	return err
-}
-
-// KeepAlive wraps the specified soap.RoundTripper and executes a meaningless
-// API request in the background after the RoundTripper has been idle for the
-// specified amount of idle time. The keep alive process only starts once a
-// user logs in and runs until the user logs out again.
+// KeepAlive is a backward compatible wrapper around KeepAliveHandler.
 func KeepAlive(roundTripper soap.RoundTripper, idleTime time.Duration) soap.RoundTripper {
-	return KeepAliveHandler(roundTripper, idleTime, defaultKeepAlive)
+	return KeepAliveHandler(roundTripper, idleTime, nil)
 }
 
-// KeepAliveHandler works as KeepAlive() does, but the handler param can decide how to handle errors.
-// For example, if connectivity to ESX/VC is down long enough for a session to expire, a handler can choose to
-// Login() on a types.NotAuthenticated error.  If handler returns non-nil, the keep alive go routine will be stopped.
+// KeepAliveHandler is a backward compatible wrapper around keepalive.NewHandlerSOAP.
 func KeepAliveHandler(roundTripper soap.RoundTripper, idleTime time.Duration, handler func(soap.RoundTripper) error) soap.RoundTripper {
-	k := &keepAlive{
-		roundTripper:  roundTripper,
-		idleTime:      idleTime,
-		notifyRequest: make(chan struct{}),
-	}
-
-	k.keepAlive = handler
-
-	return k
-}
-
-func (k *keepAlive) start() {
-	k.Lock()
-	defer k.Unlock()
-
-	if k.notifyStop != nil {
-		return
-	}
-
-	// This channel must be closed to terminate idle timer.
-	k.notifyStop = make(chan struct{})
-	k.notifyWaitGroup.Add(1)
-
-	go func() {
-		for t := time.NewTimer(k.idleTime); ; {
-			select {
-			case <-k.notifyStop:
-				k.notifyWaitGroup.Done()
-				return
-			case <-k.notifyRequest:
-				t.Reset(k.idleTime)
-			case <-t.C:
-				if err := k.keepAlive(k.roundTripper); err != nil {
-					k.notifyWaitGroup.Done()
-					k.stop()
-					return
-				}
-				t = time.NewTimer(k.idleTime)
-			}
+	var f func() error
+	if handler != nil {
+		f = func() error {
+			return handler(roundTripper)
 		}
-	}()
-}
-
-func (k *keepAlive) stop() {
-	k.Lock()
-	defer k.Unlock()
-
-	if k.notifyStop != nil {
-		close(k.notifyStop)
-		k.notifyWaitGroup.Wait()
-		k.notifyStop = nil
 	}
-}
-
-func (k *keepAlive) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
-	// Stop ticker on logout.
-	switch req.(type) {
-	case *methods.LogoutBody:
-		k.stop()
-	}
-
-	err := k.roundTripper.RoundTrip(ctx, req, res)
-	if err != nil {
-		return err
-	}
-	// Start ticker on login.
-	switch req.(type) {
-	case *methods.LoginBody, *methods.LoginExtensionByCertificateBody, *methods.LoginByTokenBody:
-		k.start()
-	}
-
-	return nil
+	return keepalive.NewHandlerSOAP(roundTripper, idleTime, f)
 }

--- a/vendor/github.com/vmware/govmomi/session/keepalive/handler.go
+++ b/vendor/github.com/vmware/govmomi/session/keepalive/handler.go
@@ -1,0 +1,204 @@
+/*
+Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keepalive
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// handler contains the generic keep alive settings and logic
+type handler struct {
+	mu              sync.Mutex
+	notifyStop      chan struct{}
+	notifyWaitGroup sync.WaitGroup
+
+	idle time.Duration
+	send func() error
+}
+
+// NewHandlerSOAP returns a soap.RoundTripper for use with a vim25.Client
+// The idle time specifies the interval in between send() requests. Defaults to 10 minutes.
+// The send func is used to keep a session alive. Defaults to calling vim25 GetCurrentTime().
+// The keep alive goroutine starts when a Login method is called and runs until Logout is called or send returns an error.
+func NewHandlerSOAP(c soap.RoundTripper, idle time.Duration, send func() error) *HandlerSOAP {
+	h := &handler{
+		idle: idle,
+		send: send,
+	}
+
+	if send == nil {
+		h.send = func() error {
+			return h.keepAliveSOAP(c)
+		}
+	}
+
+	return &HandlerSOAP{h, c}
+}
+
+// NewHandlerREST returns an http.RoundTripper for use with a rest.Client
+// The idle time specifies the interval in between send() requests. Defaults to 10 minutes.
+// The send func is used to keep a session alive. Defaults to calling the rest.Client.Session() method
+// The keep alive goroutine starts when a Login method is called and runs until Logout is called or send returns an error.
+func NewHandlerREST(c *rest.Client, idle time.Duration, send func() error) *HandlerREST {
+	h := &handler{
+		idle: idle,
+		send: send,
+	}
+
+	if send == nil {
+		h.send = func() error {
+			return h.keepAliveREST(c)
+		}
+	}
+
+	return &HandlerREST{h, c.Transport}
+}
+
+func (h *handler) keepAliveSOAP(rt soap.RoundTripper) error {
+	ctx := context.Background()
+	_, err := methods.GetCurrentTime(ctx, rt)
+	return err
+}
+
+func (h *handler) keepAliveREST(c *rest.Client) error {
+	ctx := context.Background()
+
+	s, err := c.Session(ctx)
+	if err != nil {
+		return err
+	}
+	if s != nil {
+		return nil
+	}
+	return errors.New(http.StatusText(http.StatusUnauthorized))
+}
+
+// Start explicitly starts the keep alive go routine.
+// For use with session cache.Client, as cached sessions may not involve Login/Logout via RoundTripper.
+func (h *handler) Start() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.notifyStop != nil {
+		return
+	}
+
+	if h.idle == 0 {
+		h.idle = time.Minute * 10
+	}
+
+	// This channel must be closed to terminate idle timer.
+	h.notifyStop = make(chan struct{})
+	h.notifyWaitGroup.Add(1)
+
+	go func() {
+		for t := time.NewTimer(h.idle); ; {
+			select {
+			case <-h.notifyStop:
+				h.notifyWaitGroup.Done()
+				t.Stop()
+				return
+			case <-t.C:
+				if err := h.send(); err != nil {
+					h.notifyWaitGroup.Done()
+					h.Stop()
+					return
+				}
+				t.Reset(h.idle)
+			}
+		}
+	}()
+}
+
+// Stop explicitly stops the keep alive go routine.
+// For use with session cache.Client, as cached sessions may not involve Login/Logout via RoundTripper.
+func (h *handler) Stop() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.notifyStop != nil {
+		close(h.notifyStop)
+		h.notifyWaitGroup.Wait()
+		h.notifyStop = nil
+	}
+}
+
+// HandlerSOAP is a keep alive implementation for use with vim25.Client
+type HandlerSOAP struct {
+	*handler
+
+	roundTripper soap.RoundTripper
+}
+
+// RoundTrip implements soap.RoundTripper
+func (h *HandlerSOAP) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
+	// Stop ticker on logout.
+	switch req.(type) {
+	case *methods.LogoutBody:
+		h.Stop()
+	}
+
+	err := h.roundTripper.RoundTrip(ctx, req, res)
+	if err != nil {
+		return err
+	}
+
+	// Start ticker on login.
+	switch req.(type) {
+	case *methods.LoginBody, *methods.LoginExtensionByCertificateBody, *methods.LoginByTokenBody:
+		h.Start()
+	}
+
+	return nil
+}
+
+// HandlerREST is a keep alive implementation for use with rest.Client
+type HandlerREST struct {
+	*handler
+
+	roundTripper http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper
+func (h *HandlerREST) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Path != "/rest/com/vmware/cis/session" {
+		return h.roundTripper.RoundTrip(req)
+	}
+
+	if req.Method == http.MethodDelete { // Logout
+		h.Stop()
+	}
+
+	res, err := h.roundTripper.RoundTrip(req)
+	if err != nil {
+		return res, err
+	}
+
+	if req.Method == http.MethodPost { // Login
+		h.Start()
+	}
+
+	return res, err
+}

--- a/vendor/github.com/vmware/govmomi/simulator/host_network_system.go
+++ b/vendor/github.com/vmware/govmomi/simulator/host_network_system.go
@@ -46,6 +46,16 @@ func NewHostNetworkSystem(host *mo.HostSystem) *HostNetworkSystem {
 	}
 }
 
+func (s *HostNetworkSystem) init(r *Registry) {
+	for _, obj := range r.objects {
+		if h, ok := obj.(*HostSystem); ok {
+			if h.ConfigManager.NetworkSystem.Value == s.Self.Value {
+				s.Host = &h.HostSystem
+			}
+		}
+	}
+}
+
 func (s *HostNetworkSystem) folder() *Folder {
 	f := Map.getEntityDatacenter(s.Host).NetworkFolder
 	return Map.Get(f).(*Folder)
@@ -181,6 +191,22 @@ func (s *HostNetworkSystem) UpdateNetworkConfig(req *types.UpdateNetworkConfig) 
 	return &methods.UpdateNetworkConfigBody{
 		Res: &types.UpdateNetworkConfigResponse{
 			Returnval: types.HostNetworkConfigResult{},
+		},
+	}
+}
+
+func (s *HostNetworkSystem) QueryNetworkHint(req *types.QueryNetworkHint) soap.HasFault {
+	var info []types.PhysicalNicHintInfo
+
+	for _, nic := range s.Host.Config.Network.Pnic {
+		info = append(info, types.PhysicalNicHintInfo{
+			Device: nic.Device,
+		})
+	}
+
+	return &methods.QueryNetworkHintBody{
+		Res: &types.QueryNetworkHintResponse{
+			Returnval: info,
 		},
 	}
 }

--- a/vendor/github.com/vmware/govmomi/simulator/host_system.go
+++ b/vendor/github.com/vmware/govmomi/simulator/host_system.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"net"
 	"os"
 	"time"
 
@@ -63,6 +64,10 @@ func NewHostSystem(host mo.HostSystem) *HostSystem {
 	info := *esx.HostHardwareInfo
 	hs.Hardware = &info
 
+	cfg := new(types.HostConfigInfo)
+	deepCopy(hs.Config, cfg)
+	hs.Config = cfg
+
 	config := []struct {
 		ref **types.ManagedObjectReference
 		obj mo.Reference
@@ -87,6 +92,9 @@ func (h *HostSystem) configure(spec types.HostConnectSpec, connected bool) {
 	h.Runtime.ConnectionState = types.HostSystemConnectionStateDisconnected
 	if connected {
 		h.Runtime.ConnectionState = types.HostSystemConnectionStateConnected
+	}
+	if net.ParseIP(spec.HostName) != nil {
+		h.Config.Network.Vnic[0].Spec.Ip.IpAddress = spec.HostName
 	}
 
 	h.Summary.Config.Name = spec.HostName

--- a/vendor/github.com/vmware/govmomi/simulator/model.go
+++ b/vendor/github.com/vmware/govmomi/simulator/model.go
@@ -237,6 +237,7 @@ var kinds = map[string]reflect.Type{
 	"GuestOperationsManager":         reflect.TypeOf((*GuestOperationsManager)(nil)).Elem(),
 	"HostDatastoreBrowser":           reflect.TypeOf((*HostDatastoreBrowser)(nil)).Elem(),
 	"HostLocalAccountManager":        reflect.TypeOf((*HostLocalAccountManager)(nil)).Elem(),
+	"HostNetworkSystem":              reflect.TypeOf((*HostNetworkSystem)(nil)).Elem(),
 	"HostSystem":                     reflect.TypeOf((*HostSystem)(nil)).Elem(),
 	"IpPoolManager":                  reflect.TypeOf((*IpPoolManager)(nil)).Elem(),
 	"LicenseManager":                 reflect.TypeOf((*LicenseManager)(nil)).Elem(),

--- a/vendor/github.com/vmware/govmomi/simulator/object.go
+++ b/vendor/github.com/vmware/govmomi/simulator/object.go
@@ -17,10 +17,13 @@ limitations under the License.
 package simulator
 
 import (
+	"bytes"
+
 	"github.com/google/uuid"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vim25/xml"
 )
 
 func SetCustomValue(ctx *Context, req *types.SetCustomValue) soap.HasFault {
@@ -58,4 +61,19 @@ func newUUID(s string) string {
 // sha1UUID returns a stable UUID based on input s
 func sha1UUID(s string) uuid.UUID {
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(s))
+}
+
+// deepCopy uses xml encode/decode to copy src to dst
+func deepCopy(src, dst interface{}) {
+	b, err := xml.Marshal(src)
+	if err != nil {
+		panic(err)
+	}
+
+	dec := xml.NewDecoder(bytes.NewReader(b))
+	dec.TypeFunc = types.TypeFunc()
+	err = dec.Decode(dst)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/vendor/github.com/vmware/govmomi/simulator/view_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/view_manager.go
@@ -139,7 +139,7 @@ func (v *ContainerView) include(o types.ManagedObjectReference) bool {
 }
 
 func walk(root mo.Reference, f func(child types.ManagedObjectReference)) {
-	if _, ok := root.(types.ManagedObjectReference); ok {
+	if _, ok := root.(types.ManagedObjectReference); ok || root == nil {
 		return
 	}
 

--- a/vendor/github.com/vmware/govmomi/simulator/virtual_machine.go
+++ b/vendor/github.com/vmware/govmomi/simulator/virtual_machine.go
@@ -1894,7 +1894,7 @@ func (vm *VirtualMachine) CreateSnapshotTask(req *types.CreateSnapshot_Task) soa
 		changes = append(changes, types.PropertyChange{Name: "snapshot.currentSnapshot", Val: snapshot.Self})
 		Map.Update(vm, changes)
 
-		return nil, nil
+		return snapshot.Self, nil
 	})
 
 	return &methods.CreateSnapshot_TaskBody{

--- a/vendor/github.com/vmware/govmomi/vapi/appliance/logging/forwarding.go
+++ b/vendor/github.com/vmware/govmomi/vapi/appliance/logging/forwarding.go
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0.
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+const applianceLoggingForwardingPath = "/appliance/logging/forwarding"
+
+// Manager provides convenience methods to configure appliance logging forwarding.
+type Manager struct {
+	*rest.Client
+}
+
+// NewManager creates a new Manager with the given client
+func NewManager(client *rest.Client) *Manager {
+	return &Manager{
+		Client: client,
+	}
+}
+
+// Forwarding represents configuration for log message forwarding.
+type Forwarding struct {
+	Hostname string `json:"hostname,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	Protocol string `json:"protocol,omitempty"`
+}
+
+func (m *Manager) getManagerResource() *rest.Resource {
+	return m.Resource(applianceLoggingForwardingPath)
+}
+
+// Forwarding returns all logging forwarding config.
+func (m *Manager) Forwarding(ctx context.Context) ([]Forwarding, error) {
+	r := m.getManagerResource()
+	var res []Forwarding
+	return res, m.Do(ctx, r.Request(http.MethodGet), &res)
+}

--- a/vendor/github.com/vmware/govmomi/vcsim/README.md
+++ b/vendor/github.com/vmware/govmomi/vcsim/README.md
@@ -255,7 +255,7 @@ Network                 /godc/network/VM Network
 ## Generated inventory names
 
 The generated names include a prefix per-type and integer suffix per-instance.
-See the [simulator.Model](model) documentation for a complete list of type prefixes.
+See the [simulator.Model][model] documentation for a complete list of type prefixes.
 For example, the name **DC0_C1_RP0_VM6** is composed of:
 
 | Prefix | Instance | Type                   | Flag     |
@@ -352,3 +352,11 @@ For more details on vcsim features, see the project [wiki](https://github.com/vm
 ## Related projects
 
 * [LocalStack](https://github.com/localstack/localstack/blob/master/README.md#why-localstack)
+
+## License
+
+vcsim is available under the [Apache 2 license](../LICENSE).
+
+## Name
+
+Pronounced "v-c-sim", short for "vCenter Simulator"

--- a/vendor/github.com/vmware/govmomi/vim25/client.go
+++ b/vendor/github.com/vmware/govmomi/vim25/client.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	Namespace = "vim25"
-	Version   = "6.7"
+	Version   = "7.0"
 	Path      = "/sdk"
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -265,7 +265,7 @@ github.com/sirupsen/logrus
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
-# github.com/vmware/govmomi v0.22.2-0.20200505195818-967bc5808c63
+# github.com/vmware/govmomi v0.23.1
 ## explicit
 github.com/vmware/govmomi
 github.com/vmware/govmomi/event
@@ -338,6 +338,7 @@ github.com/vmware/govmomi/govc/tags/association
 github.com/vmware/govmomi/govc/tags/category
 github.com/vmware/govmomi/govc/task
 github.com/vmware/govmomi/govc/vapp
+github.com/vmware/govmomi/govc/vcsa/log
 github.com/vmware/govmomi/govc/version
 github.com/vmware/govmomi/govc/vm
 github.com/vmware/govmomi/govc/vm/disk
@@ -366,6 +367,7 @@ github.com/vmware/govmomi/performance
 github.com/vmware/govmomi/property
 github.com/vmware/govmomi/session
 github.com/vmware/govmomi/session/cache
+github.com/vmware/govmomi/session/keepalive
 github.com/vmware/govmomi/simulator
 github.com/vmware/govmomi/simulator/esx
 github.com/vmware/govmomi/simulator/internal
@@ -378,6 +380,7 @@ github.com/vmware/govmomi/sts/internal
 github.com/vmware/govmomi/sts/simulator
 github.com/vmware/govmomi/task
 github.com/vmware/govmomi/units
+github.com/vmware/govmomi/vapi/appliance/logging
 github.com/vmware/govmomi/vapi/cluster
 github.com/vmware/govmomi/vapi/cluster/internal
 github.com/vmware/govmomi/vapi/cluster/simulator


### PR DESCRIPTION
- Add keep-alives to SOAP/REST clients
- `source` is extracted from the underlying client connection
- Make secret mount path configurable via env for local testing
- Remove naming conflicts with imported packages
- Update docs with changes and clean build instructions

Closes: #140 

Signed-off-by: Michael Gasch <mgasch@vmware.com>