### PR TITLE
fix ko install

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -24,7 +24,9 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        GO111MODULE=on go get github.com/google/ko/cmd/ko@master
+        curl -L https://github.com/google/ko/releases/download/v0.7.0/ko_0.7.0_Linux_x86_64.tar.gz | tar xzf - ko
+        chmod +x ./ko
+        sudo mv ko /usr/local/bin
 
     - name: Check out code onto GOPATH
       uses: actions/checkout@v2


### PR DESCRIPTION
Somewhere along the way the ko install stopped working, we've been having to do this all over the place, so install from the release.