### PR TITLE
Add configurable checkpoints

### DIFF
--- a/pkg/apis/sources/v1alpha1/vspheresource_defaults.go
+++ b/pkg/apis/sources/v1alpha1/vspheresource_defaults.go
@@ -9,10 +9,18 @@ import (
 	"context"
 
 	"knative.dev/pkg/apis"
+
+	"github.com/vmware-tanzu/sources-for-knative/pkg/vsphere"
 )
 
 // SetDefaults implements apis.Defaultable
 func (vs *VSphereSource) SetDefaults(ctx context.Context) {
 	withNS := apis.WithinParent(ctx, vs.ObjectMeta)
 	vs.Spec.Sink.SetDefaults(withNS)
+
+	// only checking period, setting maxAge to 0 will disable event replay
+	// to get at-most-once semantics
+	if vs.Spec.CheckpointConfig.PeriodSeconds == 0 {
+		vs.Spec.CheckpointConfig.PeriodSeconds = int64(vsphere.CheckpointDefaultPeriod.Seconds())
+	}
 }

--- a/pkg/apis/sources/v1alpha1/vspheresource_defaults_test.go
+++ b/pkg/apis/sources/v1alpha1/vspheresource_defaults_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/vmware-tanzu/sources-for-knative/pkg/vsphere"
 )
 
 func TestVSphereSourceDefaulting(t *testing.T) {
@@ -37,6 +39,10 @@ func TestVSphereSourceDefaulting(t *testing.T) {
 			Spec: VSphereSourceSpec{
 				SourceSpec: validSourceSpec,
 				VAuthSpec:  validVAuthSpec,
+				CheckpointConfig: VCheckpointSpec{
+					MaxAgeSeconds: 0,
+					PeriodSeconds: int64(vsphere.CheckpointDefaultPeriod.Seconds()),
+				},
 			},
 		},
 	}, {
@@ -76,6 +82,38 @@ func TestVSphereSourceDefaulting(t *testing.T) {
 					},
 				},
 				VAuthSpec: validVAuthSpec,
+				CheckpointConfig: VCheckpointSpec{
+					MaxAgeSeconds: 0,
+					PeriodSeconds: int64(vsphere.CheckpointDefaultPeriod.Seconds()),
+				},
+			},
+		},
+	}, {
+		name: "custom checkpoint config",
+		c: &VSphereSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: VSphereSourceSpec{
+				SourceSpec: validSourceSpec,
+				VAuthSpec:  validVAuthSpec,
+				CheckpointConfig: VCheckpointSpec{
+					MaxAgeSeconds: 3600,
+					PeriodSeconds: 60,
+				},
+			},
+		},
+		want: &VSphereSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: VSphereSourceSpec{
+				SourceSpec: validSourceSpec,
+				VAuthSpec:  validVAuthSpec,
+				CheckpointConfig: VCheckpointSpec{
+					MaxAgeSeconds: 3600,
+					PeriodSeconds: 60,
+				},
 			},
 		},
 	}}

--- a/pkg/apis/sources/v1alpha1/vspheresource_types.go
+++ b/pkg/apis/sources/v1alpha1/vspheresource_types.go
@@ -41,7 +41,13 @@ var _ kmeta.OwnerRefable = (*VSphereSource)(nil)
 type VSphereSourceSpec struct {
 	duckv1.SourceSpec `json:",inline"`
 
-	VAuthSpec `json:",inline"`
+	VAuthSpec        `json:",inline"`
+	CheckpointConfig VCheckpointSpec `json:"checkpointConfig"`
+}
+
+type VCheckpointSpec struct {
+	MaxAgeSeconds int64 `json:"maxAgeSeconds"`
+	PeriodSeconds int64 `json:"periodSeconds"`
 }
 
 const (

--- a/pkg/apis/sources/v1alpha1/vspheresource_validation.go
+++ b/pkg/apis/sources/v1alpha1/vspheresource_validation.go
@@ -18,5 +18,18 @@ func (vs *VSphereSource) Validate(ctx context.Context) *apis.FieldError {
 
 // Validate implements apis.Validatable
 func (vsss *VSphereSourceSpec) Validate(ctx context.Context) *apis.FieldError {
-	return vsss.Sink.Validate(ctx).ViaField("sink").Also(vsss.VAuthSpec.Validate(ctx))
+	return vsss.Sink.Validate(ctx).ViaField("sink").Also(vsss.VAuthSpec.Validate(ctx)).Also(vsss.CheckpointConfig.
+		Validate(ctx))
+}
+
+func (vcs VCheckpointSpec) Validate(ctx context.Context) (err *apis.FieldError) {
+	if vcs.PeriodSeconds < 0 {
+		err = err.Also(apis.ErrInvalidValue(vcs.PeriodSeconds, "checkpointConfig.periodSeconds"))
+	}
+
+	if vcs.MaxAgeSeconds < 0 {
+		err = err.Also(apis.ErrInvalidValue(vcs.MaxAgeSeconds, "checkpointConfig.maxAgeSeconds"))
+	}
+
+	return err
 }

--- a/pkg/apis/sources/v1alpha1/vspheresource_validation_test.go
+++ b/pkg/apis/sources/v1alpha1/vspheresource_validation_test.go
@@ -68,6 +68,23 @@ func TestVSphereSourceValidation(t *testing.T) {
 			},
 		},
 		want: apis.ErrGeneric("expected at least one, got none", "spec.sink.ref", "spec.sink.uri"),
+	}, {
+		name: "invalid CheckpointConfig",
+		c: &VSphereSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: VSphereSourceSpec{
+				SourceSpec: validSourceSpec,
+				VAuthSpec:  validVAuthSpec,
+				CheckpointConfig: VCheckpointSpec{
+					MaxAgeSeconds: -10,
+					PeriodSeconds: -5,
+				},
+			},
+		},
+		want: apis.ErrInvalidValue("-10", "spec.checkpointConfig.maxAgeSeconds").Also(apis.ErrInvalidValue("-5",
+			"spec.checkpointConfig.periodSeconds")),
 	}}
 
 	for _, test := range tests {

--- a/pkg/vsphere/adapter_test.go
+++ b/pkg/vsphere/adapter_test.go
@@ -239,24 +239,24 @@ func Test_getBeginFromCheckpoint(t *testing.T) {
 			args: args{
 				vcTime: now,
 				cp:     checkpoint{},
-				maxAge: checkpointDefaultAge,
+				maxAge: CheckpointDefaultAge,
 			},
 			want: now,
 		},
 		{
-			name: "checkpoint too old (use checkpointDefaultAge)",
+			name: "checkpoint too old (use CheckpointDefaultAge)",
 			args: args{
 				vcTime: now,
 				cp: checkpoint{
 					LastEventKey:          1234,
 					LastEventKeyTimestamp: now.Add(time.Hour * -1),
 				},
-				maxAge: checkpointDefaultAge,
+				maxAge: CheckpointDefaultAge,
 			},
-			want: now.Add(checkpointDefaultAge * -1),
+			want: now.Add(CheckpointDefaultAge * -1),
 		},
 		{
-			name: "valid checkpoint within custom checkpointConfig maxAge",
+			name: "valid checkpoint within custom CheckpointConfig maxAge",
 			args: args{
 				vcTime: now,
 				cp: checkpoint{
@@ -290,7 +290,7 @@ func Test_vAdapter_run(t *testing.T) {
 		StatusCodes []int
 		Source      string
 		KVStore     kvstore.Interface
-		CpConfig    checkpointConfig
+		CpConfig    CheckpointConfig
 	}
 	tests := []struct {
 		name              string
@@ -304,8 +304,8 @@ func Test_vAdapter_run(t *testing.T) {
 				StatusCodes: nil, // we don't send any events
 				Source:      source,
 				KVStore:     &fakeKVStore{},
-				CpConfig: checkpointConfig{
-					MaxAge: checkpointDefaultAge,
+				CpConfig: CheckpointConfig{
+					MaxAge: CheckpointDefaultAge,
 					Period: time.Millisecond,
 				},
 			},
@@ -323,7 +323,7 @@ func Test_vAdapter_run(t *testing.T) {
 					},
 					dataChan: make(chan string, 1),
 				},
-				CpConfig: checkpointConfig{
+				CpConfig: CheckpointConfig{
 					MaxAge: time.Hour,
 					Period: time.Millisecond,
 				},
@@ -342,7 +342,7 @@ func Test_vAdapter_run(t *testing.T) {
 					},
 					dataChan: make(chan string, 1),
 				},
-				CpConfig: checkpointConfig{
+				CpConfig: CheckpointConfig{
 					MaxAge: time.Hour,
 					Period: time.Millisecond,
 				},

--- a/pkg/vsphere/checkpoint_test.go
+++ b/pkg/vsphere/checkpoint_test.go
@@ -11,6 +11,129 @@ import (
 	"time"
 )
 
+func Test_checkpointConfig_UnmarshalJSON(t *testing.T) {
+	type args struct {
+		b []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *CheckpointConfig
+		wantErr bool
+	}{
+		{
+			name: "valid config human-readable time",
+			args: args{b: []byte(`{"maxAge":"1h","period":"10s"}`)},
+			want: &CheckpointConfig{
+				MaxAge: time.Hour,
+				Period: 10 * time.Second,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid config with seconds-encoded time",
+			args:    args{b: []byte(`{"maxAge":3600000000000,"period":10000000000}`)},
+			want:    &CheckpointConfig{},
+			wantErr: true,
+		},
+		{
+			name:    "invalid config",
+			args:    args{b: []byte(`{"maxAge":}`)},
+			want:    &CheckpointConfig{},
+			wantErr: true,
+		},
+		{
+			name:    "invalid config (negative values)",
+			args:    args{b: []byte(`{"maxAge":"-1ns","period":"-1m"}`)},
+			want:    &CheckpointConfig{},
+			wantErr: true,
+		},
+		{
+			name: "empty config",
+			args: args{b: []byte(`{}`)},
+			want: &CheckpointConfig{
+				MaxAge: CheckpointDefaultAge,
+				Period: CheckpointDefaultPeriod,
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty config with zero values",
+			args: args{b: []byte(`{"maxAge":"0s","period":"0s"}`)},
+			want: &CheckpointConfig{
+				MaxAge: time.Second * 0,
+				Period: time.Second * 0,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := &CheckpointConfig{}
+			if err := got.UnmarshalJSON(tt.args.b); (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MarshalJSON() got = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_checkpointConfig_MarshalJSON(t *testing.T) {
+	type fields struct {
+		MaxAge time.Duration
+		Period time.Duration
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:    "empty config with zero values",
+			fields:  fields{},
+			want:    []byte(`{"maxAge":"0s","period":"0s"}`),
+			wantErr: false,
+		},
+		{
+			name: "default config values",
+			fields: fields{
+				MaxAge: CheckpointDefaultAge,
+				Period: CheckpointDefaultPeriod,
+			},
+			want:    []byte(`{"maxAge":"5m0s","period":"10s"}`),
+			wantErr: false,
+		},
+		{
+			name: "invalid values",
+			fields: fields{
+				MaxAge: -1,
+				Period: -2,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &CheckpointConfig{
+				MaxAge: tt.fields.MaxAge,
+				Period: tt.fields.Period,
+			}
+			got, err := c.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MarshalJSON() got = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_newCheckpointConfig(t *testing.T) {
 	type args struct {
 		config string
@@ -18,13 +141,13 @@ func Test_newCheckpointConfig(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *checkpointConfig
+		want    *CheckpointConfig
 		wantErr bool
 	}{
 		{
 			name: "valid config human-readable time",
 			args: args{config: `{"maxAge":"1h","period":"10s"}`},
-			want: &checkpointConfig{
+			want: &CheckpointConfig{
 				MaxAge: 1 * time.Hour,
 				Period: 10 * time.Second,
 			},
@@ -45,9 +168,18 @@ func Test_newCheckpointConfig(t *testing.T) {
 		{
 			name: "empty config (use defaults)",
 			args: args{config: `{}`},
-			want: &checkpointConfig{
-				MaxAge: checkpointDefaultAge,
-				Period: checkpointDefaultPeriod,
+			want: &CheckpointConfig{
+				MaxAge: CheckpointDefaultAge,
+				Period: CheckpointDefaultPeriod,
+			},
+			wantErr: false,
+		},
+		{
+			name: "config with zero values",
+			args: args{config: `{"maxAge":"0s","period":"0s"}`},
+			want: &CheckpointConfig{
+				MaxAge: time.Duration(0),
+				Period: CheckpointDefaultPeriod,
 			},
 			wantErr: false,
 		},

--- a/plugins/vsphere/README.adoc
+++ b/plugins/vsphere/README.adoc
@@ -70,21 +70,27 @@ Examples:
 kn vsphere source --name source --address https://my-vsphere-endpoint.local --skip-tls-verify --secret-ref vsphere-credentials --sink-uri http://where.to.send.stuff
 # Create the source in the specified namespace, sending events to the specified service
 kn vsphere source --namespace ns --name source --address https://my-vsphere-endpoint.local --skip-tls-verify --secret-ref vsphere-credentials --sink-api-version v1 --sink-kind Service --sink-name the-service-name
+# Create the source in the specified namespace, sending events to the specified service with custom checkpoint behavior
+kn vsphere source --namespace ns --name source --address https://my-vsphere-endpoint.local --skip-tls-verify
+--secret-ref vsphere-credentials --sink-api-version v1 --sink-kind Service --sink-name the-service-name
+--checkpoint-age 1h --checkpoint-period 30s
 
 Usage:
   kn-vsphere source [flags]
 
 Flags:
-  -a, --address string            URL of ESXi or vCenter instance to connect to (same as VC_URL)
-  -h, --help                      help for source
-      --name string               name of the source to create
-  -n, --namespace string          namespace of the source to create (default namespace if omitted)
-  -s, --secret-ref string         reference to the Kubernetes secret for the vSphere credentials needed for the source address
-      --sink-api-version string   sink API version
-      --sink-kind string          sink kind
-      --sink-name string          sink name
-  -u, --sink-uri string           sink URI (can be absolute, or relative to the referred sink resource)
-  -k, --skip-tls-verify           disables certificate verification for the source address (same as VC_INSECURE)
+  -a, --address string               URL of ESXi or vCenter instance to connect to (same as VC_URL)
+      --checkpoint-age duration      maximum allowed age for replaying events determined by last successful event in checkpoint (default 5m0s)
+      --checkpoint-period duration   period between saving checkpoints (default 10s)
+  -h, --help                         help for source
+      --name string                  name of the source to create
+  -n, --namespace string             namespace of the source to create (default namespace if omitted)
+  -s, --secret-ref string            reference to the Kubernetes secret for the vSphere credentials needed for the source address
+      --sink-api-version string      sink API version
+      --sink-kind string             sink kind
+      --sink-name string             sink name
+  -u, --sink-uri string              sink URI (can be absolute, or relative to the referred sink resource)
+  -k, --skip-tls-verify              disables certificate verification for the source address (same as VC_INSECURE)
 ----
 
 ==== `kn vsphere binding`


### PR DESCRIPTION
This change allows to configure the checkpointing behavior in the spec of the vSphere source. If no or zero values for `maxAgeSeconds` and `periodSeconds` are specified, sane defaults will be applied. Optionally, this behavior can be configured via the `kn` vsphere plugin. Thus, two new flags are introduced, `checkpoint-age` and `checkpoint-period`. Both use the same defaults as in the controller logic if not explicitly specified.

Create a vSphere Source with `kn` plugin:

```bash
# 24h checkpoint replay window, checkpoint every 1s (not recommended!)
./vsphere source --name vc-source --address https://10.161.153.226 --skip-tls-verify --secret-ref vsphere-credentials --sink-uri http://broker-ingress.knative-eventing.svc.cluster.local/default/default --checkpoint-age 24h --checkpoint-period 1s
```

Example of vSphere Source Spec:

```json
{
  "address": "https://10.161.153.226",
  "checkpointConfig": {
    "maxAgeSeconds": 86400,
    "periodSeconds": 1
  },
  "secretRef": {
    "name": "vsphere-credentials"
  },
  "sink": {
    "uri": "http://broker-ingress.knative-eventing.svc.cluster.local/default/default"
  },
  "skipTLSVerify": true
}
```

> **Note:** Using **int64** encoding in seconds for time values, following Kubernetes conventions

After creation of a vSphere source spec, the source adapter (`deployment`) will be injected with a JSON-encoded environment variable reflecting the `checkpointConfig`:

```json
{
  "name": "VSPHERE_CHECKPOINT_CONFIG",
  "value": "{\"maxAge\":\"24h0m0s\",\"period\":\"1s\"}"
}
```

> **Note:** using custom JSON (un)marshalling to support human-readable time values instead of Go Nanoseconds for Durations. This is merely to ease debugging and improve operator friendliness.

The `deployment` reflects the setting during startup:

```bash
default vc-source-deployment-6558c48c49-dqjlr adapter {"severity":"INFO","timestamp":"2021-02-09T14:10:15.71094Z","logger":"vspheresource","caller":"vsphere/adapter.go:82","message":"configuring checkpointing","commit":"0491336","ReplayWindow":"24h0m0s","Period":"1s"}
```

Closes: #185 
Closes: #186 

Signed-off-by: Michael Gasch <mgasch@vmware.com>