### PR TITLE
Fix kubectl output

### DIFF
--- a/config/300-vspheresource.yaml
+++ b/config/300-vspheresource.yaml
@@ -25,9 +25,12 @@ spec:
   subresources:
     status: {}
   additionalPrinterColumns:
-  - name: Address
+  - name: Source
     type: string
-    JSONPath: .status.address.url
+    JSONPath: .spec.address
+  - name: Sink
+    type: string
+    JSONPath: .status.sinkUri
   - name: Ready
     type: string
     JSONPath: ".status.conditions[?(@.type=='Ready')].status"


### PR DESCRIPTION
Fixes kubectl output not showing the address (Sink) and also adds a new
column for the source (vCenter).

Closes: #199 

Signed-off-by: Michael Gasch <mgasch@vmware.com>