### PR TITLE
Add install from release to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ for vSphere events, and a Binding to easily access the VSphere API.
 [release](https://github.com/vmware-tanzu/sources-for-knative/releases) and
 deploy it via `kubectl`.
 
-## Install Source
+## Install Tanzu Sources for Knative
+### Install via Release
+```
+kubectl apply -f https://github.com/vmware-tanzu/sources-for-knative/releases/download/v0.21.0/release.yaml
+```
+
+### Install from Source
 
 Install the CRD providing the control / dataplane for the
 `VSphere{Source,Binding}`:


### PR DESCRIPTION
Restructure installation options, adding a section on installing from a
release in addition to installing from source.

Should be kept in sync when new releases are created.

Closes #214 

Signed-off-by: Michael Gasch <mgasch@vmware.com>