### PR TITLE
Build E2E images only for target platform

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -65,7 +65,7 @@ jobs:
         # Build and Publish our containers to the docker daemon (including test assets)
         export GO111MODULE=on
         export GOFLAGS=-mod=vendor
-        ko apply --platform=all -PRf config/ -f test/config
+        ko apply -PRf config/ -f test/config
 
         # Build Knative plugin and create Secret
         go build -o kn-vsphere ./plugins/vsphere/cmd/vsphere

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -8,7 +8,7 @@
 export GO111MODULE=on
 export GOFLAGS=-mod=vendor
 
-cat | ko resolve --platform=all -Bf - <<EOF
+cat | ko resolve -Bf - <<EOF
 images:
 - ko://github.com/vmware/govmomi/govc
 - ko://github.com/vmware-tanzu/sources-for-knative/test/test_images/listener


### PR DESCRIPTION
Avoid building multi-platform images during E2E tests to reduce running
time and energy footprint.

Closes: #229
Signed-off-by: Michael Gasch <mgasch@vmware.com>