### PR TITLE
Migrate CRDs to apiextensions.k8s.io/v1

### DIFF
--- a/config/300-vspherebinding.yaml
+++ b/config/300-vspherebinding.yaml
@@ -1,7 +1,7 @@
 # Copyright 2020 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: vspherebindings.sources.tanzu.vmware.com
@@ -10,7 +10,6 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: sources.tanzu.vmware.com
-  version: v1alpha1
   names:
     kind: VSphereBinding
     plural: vspherebindings
@@ -22,12 +21,21 @@ spec:
     shortNames:
     - vsb
   scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: Ready
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-  - name: Reason
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+        # TODO: use controller-gen from controller-tools to fill this in?
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"

--- a/config/300-vspheresource.yaml
+++ b/config/300-vspheresource.yaml
@@ -1,7 +1,7 @@
 # Copyright 2020 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: vspheresources.sources.tanzu.vmware.com
@@ -12,7 +12,6 @@ metadata:
     eventing.knative.dev/source: "true"
 spec:
   group: sources.tanzu.vmware.com
-  version: v1alpha1
   names:
     kind: VSphereSource
     plural: vspheresources
@@ -25,18 +24,27 @@ spec:
     shortNames:
     - vss
   scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: Source
-    type: string
-    JSONPath: .spec.address
-  - name: Sink
-    type: string
-    JSONPath: .status.sinkUri
-  - name: Ready
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-  - name: Reason
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+        # TODO: use controller-gen from controller-tools to fill this in?
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Source
+      type: string
+      jsonPath: .spec.address
+    - name: Sink
+      type: string
+      jsonPath: .status.sinkUri
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"


### PR DESCRIPTION
I didn't fill in the OpenAPI schema, so you won't get any APIServer-provided validation, but this should work for v1.15+ apiservers (at least, I didn't check when the v1 CustomResourceDefinition was introduced).

```release-note
:broom: Migrate to CRD v1 scheme
```