### PR TITLE
Make `eventclass` extension lower-case

### DIFF
--- a/pkg/vsphere/adapter.go
+++ b/pkg/vsphere/adapter.go
@@ -242,7 +242,7 @@ func (a *vAdapter) sendEvents(ctx context.Context, baseEvents []types.BaseEvent)
 
 		details := getEventDetails(be)
 		ev.SetType("com.vmware.vsphere." + details.Type)
-		ev.SetExtension("EventClass", details.Class)
+		ev.SetExtension("eventclass", details.Class)
 
 		// TODO: ingestion time?
 		ev.SetTime(be.GetEvent().CreatedTime)

--- a/pkg/vsphere/adapter_test.go
+++ b/pkg/vsphere/adapter_test.go
@@ -214,7 +214,7 @@ func createCloudEvent(eventSource string, eventID string, baseEvent types.BaseEv
 	ev.SetTime(eventTime)
 	ev.SetID(eventID)
 	ev.SetSource(eventSource)
-	ev.SetExtension("EventClass", details.Class)
+	ev.SetExtension("eventclass", details.Class)
 	if err := ev.SetData("application/xml", baseEvent); err != nil {
 		panic("Failed to SetData")
 	}


### PR DESCRIPTION
CE extension attribute keys MUST be lower-case.

```release-note
:bug: Action required: CloudEvents attribute extension attribute "eventclass" is now lower case to comply with the spec.
```

Closes: #257
Signed-off-by: Michael Gasch <mgasch@vmware.com>