### PR TITLE
Add v0 suffix to converted vSphere events

### DIFF
--- a/pkg/vsphere/adapter.go
+++ b/pkg/vsphere/adapter.go
@@ -25,6 +25,8 @@ import (
 )
 
 const (
+	// signal unstable event API for converting vSphere events to CE
+	eventTypeFormat = "com.vmware.vsphere.%s.v0"
 	// read up to max events per iteration
 	maxEventsBatch = 100
 )
@@ -241,7 +243,8 @@ func (a *vAdapter) sendEvents(ctx context.Context, baseEvents []types.BaseEvent)
 		ev.SetSource(a.Source)
 
 		details := getEventDetails(be)
-		ev.SetType("com.vmware.vsphere." + details.Type)
+
+		ev.SetType(fmt.Sprintf(eventTypeFormat, details.Type))
 		ev.SetExtension("eventclass", details.Class)
 
 		// TODO: ingestion time?

--- a/pkg/vsphere/adapter_test.go
+++ b/pkg/vsphere/adapter_test.go
@@ -210,7 +210,7 @@ func createCloudEvent(eventSource string, eventID string, baseEvent types.BaseEv
 
 	ev := cloudevents.NewEvent(cloudevents.VersionV1)
 
-	ev.SetType("com.vmware.vsphere." + details.Type)
+	ev.SetType(fmt.Sprintf(eventTypeFormat, details.Type))
 	ev.SetTime(eventTime)
 	ev.SetID(eventID)
 	ev.SetSource(eventSource)


### PR DESCRIPTION
There is no official statement around vSphere event schema compatibility across versions, e.g. between 6.x and 7.x Since vSphere events also do not carry a version property, the best we can do is to signal an unstable (i.e. potentially breaking) conversion via a `.v0` event `type` suffix. Users can use the extended attributes `eventclass` and `vsphereapiversion` (https://github.com/vmware-tanzu/sources-for-knative/pull/310) to do further filtering and assert a specific vSphere event API.

Closes: #264
Signed-off-by: Michael Gasch <mgasch@vmware.com>

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

:broom: Append `.v0` suffix to converted vSphere events in CE event `type` to indicate unstable event API.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs** for any user-facing impact

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Converted vSphere events now have a `.v0` suffix in the event type to indicate an unstable event (conversion) API.
```
