### PR TITLE
feat: Add vSphere API version to CE attributes

### DIFF
--- a/test/test_images/listener/main.go
+++ b/test/test_images/listener/main.go
@@ -8,11 +8,17 @@ package main
 import (
 	"context"
 	"log"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
+)
+
+const (
+	ceVSphereAPIKey     = "vsphereapiversion"
+	ceVSphereEventClass = "eventclass"
 )
 
 func main() {
@@ -22,23 +28,36 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
-	ctx, cancel := context.WithCancel(ctx)
-	once := sync.Once{}
 
-	if err := client.StartReceiver(ctx, func(ctx context.Context, event cloudevents.Event) error {
-		log.Printf("Received event: %s", event.String())
-		once.Do(func() {
-			// Launch a go routine to avoid blocking.
-			go func() {
-				// Ten seconds after the first event, exit normally.
-				<-time.After(10 * time.Second)
-				cancel()
-			}()
-		})
-		return nil
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Launch a go routine to avoid blocking
+	go func() {
+		timeout := 10 * time.Second
+		<-time.After(timeout)
+		logging.FromContext(ctx).Infow("cancelling context: timeout reached", "timeout", timeout)
+		cancel()
+	}()
+
+	var count int32
+	if err = client.StartReceiver(ctx, func(ctx context.Context, event cloudevents.Event) {
+		logging.FromContext(ctx).Infof("Received event: %s", event.String())
+		atomic.AddInt32(&count, 1)
+
+		// assert required CE extension attributes are always present
+		if event.Extensions()[ceVSphereEventClass] == "" {
+			logging.FromContext(ctx).Fatalf("CloudEvent extension %q not set", ceVSphereEventClass)
+		}
+		if event.Extensions()[ceVSphereAPIKey] == "" {
+			logging.FromContext(ctx).Fatalf("CloudEvent extension %q not set", ceVSphereAPIKey)
+		}
 	}); err != nil {
-		log.Fatal(err)
+		logging.FromContext(ctx).Fatalf("receiving events: %v", err)
 	}
 
-	log.Print("Fin!")
+	if count == 0 {
+		logging.FromContext(ctx).Fatalf("no events received")
+	}
+	logging.FromContext(ctx).Infow("successfully received event(s)", "count", count)
 }


### PR DESCRIPTION
Fixes #260

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Add `vsphereapiversion` CE extension attribute based on vCenter Server API

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [ ] **Docs** for any user-facing impact

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Add `vsphereapiversion` CE extension attribute for advanced filtering and API/schema validation based on vCenter Server API version. Currently vSphere events do not carry version information so this attribute can be used for advanced filtering and basic schema validation.
```
