### PR TITLE
added knative 1.x tags format support to release workflow yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+    - 'knative-v*' # Push events to matching knative 1.x tags format, i.e knative-v20.15.10
 
 name: Create Release
 


### PR DESCRIPTION
Now the release job is triggered by the new tag format used by the knative 1.x releases