### PR TITLE
allow tests to run back to back

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -59,11 +59,10 @@ jobs:
         # Build and Publish our containers to the docker daemon (including test assets)
         export GO111MODULE=on
         export GOFLAGS=-mod=vendor
-        ko apply -PRf config/ -f test/config
+        ko apply -PRf config/
 
-        # Build Knative plugin and create Secret
+        # Build Knative plugin
         go build -o kn-vsphere ./plugins/vsphere/cmd/vsphere
-        ./kn-vsphere auth create --name vsphere-credentials --username user --password pass
 
         kubectl -n vmware-sources wait --timeout=10s --for=condition=Available deploy/webhook
 

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 require (
 	github.com/hashicorp/hcl v1.0.0
 	gotest.tools/v3 v3.0.3
+	k8s.io/utils v0.0.0-20211208161948-7d6a63dca704
 	knative.dev/client v0.29.1-0.20220201152332-677276ae0ab3
 )
 
@@ -145,7 +146,6 @@ require (
 	k8s.io/cli-runtime v0.22.5 // indirect
 	k8s.io/gengo v0.0.0-20211129171323-c02415ce4185 // indirect
 	k8s.io/klog/v2 v2.40.1 // indirect
-	k8s.io/utils v0.0.0-20211208161948-7d6a63dca704 // indirect
 	knative.dev/networking v0.0.0-20220131174231-d23a06807e6c // indirect
 	knative.dev/serving v0.29.1-0.20220131194631-770b91180d43 // indirect
 	sigs.k8s.io/kustomize/api v0.8.11 // indirect

--- a/test/e2e/binding_test.go
+++ b/test/e2e/binding_test.go
@@ -26,6 +26,10 @@ func TestBindingGOVC(t *testing.T) {
 
 	clients := test.Setup(t)
 
+	//create vcsim
+	cleanupVcsim := CreateSimulator(t, clients)
+	defer cleanupVcsim()
+
 	selector, cancel := CreateJobBinding(t, clients)
 	defer cancel()
 
@@ -49,6 +53,10 @@ func TestBindingPowerCLICore(t *testing.T) {
 	defer logstream.Start(t)()
 
 	clients := test.Setup(t)
+
+	//create vcsim
+	cleanupVcsim := CreateSimulator(t, clients)
+	defer cleanupVcsim()
 
 	selector, cancel := CreateJobBinding(t, clients)
 	defer cancel()

--- a/test/e2e/source_test.go
+++ b/test/e2e/source_test.go
@@ -25,6 +25,10 @@ func TestSource(t *testing.T) {
 
 	clients := test.Setup(t)
 
+	//create vcsim
+	cleanupVcsim := CreateSimulator(t, clients)
+	defer cleanupVcsim()
+
 	// Create a job/svc that listens for events and then quits N seconds after the first is received.
 	name, wait, cancelListener := RunJobListener(t, clients)
 	defer cancelListener()

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -33,7 +33,6 @@ const (
 	vcsim        = "vcsim"
 	ns           = "default"
 	vsphereCreds = "vsphere-credentials"
-	mountPath    = "/var/bindings/vsphere"
 	user         = "user"
 	password     = "password"
 )

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -54,7 +54,7 @@ func CreateJobBinding(t *testing.T, clients *test.Clients) (map[string]string, c
 		"--name", name,
 		"--vc-address", "https://vcsim.default.svc.cluster.local",
 		"--skip-tls-verify", "true",
-		"--secret-ref", "vsphere-credentials",
+		"--secret-ref", vsphereCreds,
 		"--subject-api-version", "batch/v1",
 		"--subject-kind", "Job",
 		"--subject-selector", metav1.FormatLabelSelector(&metav1.LabelSelector{MatchLabels: selector}),
@@ -138,7 +138,7 @@ func RunJobScript(t *testing.T, clients *test.Clients, image string, command []s
 		}
 		err = clients.KubeClient.CoreV1().Pods(job.Namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", jobNameKey, job.Name)})
 		if err != nil {
-			t.Errorf("Error cleaning up pod for Job %s", job.Name)
+			t.Errorf("Error cleaning up pods for Job %s", job.Name)
 		}
 	}()
 
@@ -220,7 +220,7 @@ func RunJobListener(t *testing.T, clients *test.Clients) (string, context.Cancel
 		}
 		err = clients.KubeClient.CoreV1().Pods(job.Namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", jobNameKey, name)})
 		if err != nil {
-			t.Errorf("Error cleaning up pod for Job %s", job.Name)
+			t.Errorf("Error cleaning up pods for Job %s", job.Name)
 		}
 	}
 	waiter := func() {
@@ -323,7 +323,7 @@ func CreateSource(t *testing.T, clients *test.Clients, name string) context.Canc
 		"--name", name,
 		"--vc-address", "https://vcsim.default.svc.cluster.local",
 		"--skip-tls-verify", "true",
-		"--secret-ref", "vsphere-credentials",
+		"--secret-ref", vsphereCreds,
 		"--sink-api-version", "v1",
 		"--sink-kind", "Service",
 		"--sink-name", name,


### PR DESCRIPTION
Fixes #371 

I would like to be able to run the e2e tests multiple times without cleaning everything up. Particularly, I don't want to have to recreate the vcsim. 

From what I have seen, vcsim will remember the state of things. So if in the source test, we power off two vms, when we run again and try to power off those same vms, nothing will happen. No events will be sent, and the test will fail.

Same thing happens for the TestBindingGOVC. The tag and category will already exist, so those commands won't prompt any new events.

## Proposed Changes
- :broom: Update or clean up current behavior
- added helper functions to create/cleanup vcsim and secret
- use those helper functions in the tests
- added a checkpoint configmap to the CreateSource function. This will make sure the source goes back in time for events in case the test events happen before the source is ready.
- improved cleanup functions to also clean up completed job pods associated with listener and govc jobs

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage** (I believe this does not apply, since I am modifying a test)
- [X] **E2E tests** for any new behavior
- [ ] **Docs** for any user-facing impact (I don't believe there is any user-facing impact)

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
N/A no user-facing impact
```
