### PR TITLE
make webhook probes less agressive

### DIFF
--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -62,7 +62,8 @@ spec:
           value: webhook
 
         readinessProbe: &probe
-          periodSeconds: 1
+          failureThreshold: 6
+          initialDelaySeconds: 20
           httpGet:
             scheme: HTTPS
             port: 8443

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -62,6 +62,9 @@ spec:
           value: webhook
 
         readinessProbe: &probe
+          # Increasing the failure threshold and adding an initial delay
+          # avoids the situation where failing probes cause the webhook to restart before it can
+          # finish setup. See https://github.com/vmware-tanzu/sources-for-knative/issues/356
           failureThreshold: 6
           initialDelaySeconds: 20
           httpGet:


### PR DESCRIPTION


Fixes #356

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes
- :bug: Fix bug
- follow pattern used in knative serving to use increased failure threshold and an initial delay on liveness/readiness probes.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs** for any user-facing impact

**Release Note**

```release-note
[Bug Fix]: readiness/liveness probes are now more patient when checking for the Webhook to be ready.
```
