### PR TITLE
add option to e2e tests to supply your own vcsim image

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -88,3 +88,4 @@ jobs:
         export SYSTEM_NAMESPACE=vmware-sources
         # Run the tests tagged as e2e on the KinD cluster.
         go test -v -race -timeout=3m -tags=e2e github.com/${{ github.repository }}/test/e2e/...
+

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -73,6 +73,11 @@ jobs:
         kubectl -n vmware-sources describe pods
         kubectl -n vmware-sources get events
 
+    - name: Build vcsim image
+      working-directory: ./src/github.com/${{ github.repository }}
+      run: |
+        echo "VCSIM_IMAGE=$(ko publish -B vendor/github.com/vmware/govmomi/vcsim)" >> $GITHUB_ENV
+
     - name: Run E2E tests
       working-directory: ./src/github.com/${{ github.repository }}
       run: |

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -59,7 +59,7 @@ jobs:
         ./test/upload-test-images.sh
 
         # Build and Publish our containers to the docker daemon (including test assets)
-        export GO111MODULE=off
+        export GO111MODULE=on
         export GOFLAGS=-mod=vendor
         ko apply -PRf config/
 
@@ -76,7 +76,8 @@ jobs:
     - name: Build vcsim image
       working-directory: ./src/github.com/${{ github.repository }}
       run: |
-        echo "VCSIM_IMAGE=$(ko publish -B vendor/github.com/vmware/govmomi/vcsim)" >> $GITHUB_ENV
+        export GO111MODULE=on
+        echo "VCSIM_IMAGE=$(ko publish -B github.com/vmware/govmomi/vcsim)" >> $GITHUB_ENV
 
     - name: Run E2E tests
       working-directory: ./src/github.com/${{ github.repository }}

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -73,10 +73,6 @@ jobs:
         kubectl -n vmware-sources describe pods
         kubectl -n vmware-sources get events
 
-    - name: Build vcsim image
-      run: |
-        echo "VCSIM_IMAGE=$(ko publish -B github.com/vmware/govmomi/vcsim)" >> $GITHUB_ENV
-
     - name: Run E2E tests
       working-directory: ./src/github.com/${{ github.repository }}
       run: |

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -59,7 +59,7 @@ jobs:
         ./test/upload-test-images.sh
 
         # Build and Publish our containers to the docker daemon (including test assets)
-        export GO111MODULE=on
+        export GO111MODULE=off
         export GOFLAGS=-mod=vendor
         ko apply -PRf config/
 
@@ -72,6 +72,15 @@ jobs:
         kubectl get pods --all-namespaces
         kubectl -n vmware-sources describe pods
         kubectl -n vmware-sources get events
+
+    - name: Build vcsim image
+      run: |
+        echo "VCSIM_IMAGE=$(ko publish -B github.com/vmware/govmomi/vcsim)" >> $GITHUB_ENV
+
+    - name: Run E2E tests
+      working-directory: ./src/github.com/${{ github.repository }}
+      run: |
+        set -x
 
         # For logstream to work.
         export SYSTEM_NAMESPACE=vmware-sources

--- a/test/README.md
+++ b/test/README.md
@@ -7,6 +7,8 @@ Before you begin, make sure you have your `KO_DOCKER_REPO` env var set to whatev
 
 To run the test, you'll need to upload the test images to a registry. This can be done by running `upload-test-images.sh`.
 
+This document assumes you have already installed the Tanzu Sources, as described [here](/README.md)
+
 #### vCenter Simulator Image
 
 By default, the tests use the vCenter Simulator image `vmware/vcsim:latest`, which is hosted on Dockerhub.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,28 @@
+# E2E tests
+For insight into how the tests are run, you can check out `.github/workflows/kind-e2e.yaml`.
+
+## Setup
+
+Before you begin, make sure you have your `KO_DOCKER_REPO` env var set to whatever registry you like to use.
+
+To run the test, you'll need to upload the test images to a registry. This can be done by running `upload-test-images.sh`.
+
+#### vCenter Simulator Image
+
+By default, the tests use the vCenter Simulator image `vmware/vcsim:latest`, which is hosted on Dockerhub.
+
+If you wish to use a `vcsim` image hosted on a different registry, you can build and store it yourself with [`ko`](https://github.com/google/ko), like this:
+```
+export VCSIM_IMAGE=$(ko publish -B github.com/vmware/govmomi/vcsim)
+```
+
+## Running the tests
+The tests can be run with `go test`, like this:
+```
+go test -v -race -count=1 -tags=e2e ./test/e2e
+```
+
+You can run a specific test with the `-run` flag, like this:
+```
+go test -v -race -count=1 -tags=e2e -run='^(TestSource)$' ./test/e2e
+```

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -37,7 +37,7 @@ const (
 	user              = "user"
 	password          = "password"
 	jobNameKey        = "job-name"
-	DefaultVcsimImage = "vmware/vcsim:latest"
+	defaultVcsimImage = "vmware/vcsim:latest"
 )
 
 type envConfig struct {
@@ -447,12 +447,11 @@ func CreateSimulator(t *testing.T, clients *test.Clients) context.CancelFunc {
 }
 
 func newSimulator(namespace, image string) (*appsv1.Deployment, *corev1.Service) {
-
 	l := map[string]string{
 		"app": vcsim,
 	}
 	args := []string{"-l", ":8989"}
-	if image == DefaultVcsimImage {
+	if image == defaultVcsimImage {
 		//vmware/vcsim image is built differently, it does not use ko. Therefore, the entrypoint is different.
 		args = append([]string{"vcsim"}, args...)
 	}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -31,12 +31,13 @@ import (
 )
 
 const (
-	vcsim        = "vcsim"
-	ns           = "default"
-	vsphereCreds = "vsphere-credentials"
-	user         = "user"
-	password     = "password"
-	jobNameKey   = "job-name"
+	vcsim             = "vcsim"
+	ns                = "default"
+	vsphereCreds      = "vsphere-credentials"
+	user              = "user"
+	password          = "password"
+	jobNameKey        = "job-name"
+	DefaultVcsimImage = "vmware/vcsim:latest"
 )
 
 type envConfig struct {
@@ -450,6 +451,11 @@ func newSimulator(namespace, image string) (*appsv1.Deployment, *corev1.Service)
 	l := map[string]string{
 		"app": vcsim,
 	}
+	args := []string{"-l", ":8989"}
+	if image == DefaultVcsimImage {
+		//vmware/vcsim image is built differently, it does not use ko. Therefore, the entrypoint is different.
+		args = append([]string{"vcsim"}, args...)
+	}
 
 	sim := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -468,13 +474,9 @@ func newSimulator(namespace, image string) (*appsv1.Deployment, *corev1.Service)
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
-						Name:  vcsim,
-						Image: image,
-						Args: []string{
-							"/vcsim",
-							"-l",
-							":8989",
-						},
+						Name:            vcsim,
+						Image:           image,
+						Args:            args,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Ports: []corev1.ContainerPort{
 							{


### PR DESCRIPTION
## Proposed Changes
- :broom: Update or clean up current behavior
- allow test to use a ko built vcsim OR the vcsim hosted on dockerhub
- add some documentation on how to run the tests

### Pre-review Checklist


- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs** for any user-facing impact

**Release Note**
N/A
