### PR TITLE
Refactor: change source test listener to expect certain events

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -87,5 +87,5 @@ jobs:
         # For logstream to work.
         export SYSTEM_NAMESPACE=vmware-sources
         # Run the tests tagged as e2e on the KinD cluster.
-        go test -v -race -timeout=3m -tags=e2e github.com/${{ github.repository }}/test/e2e/...
+        go test -v -race -timeout=10m -tags=e2e github.com/${{ github.repository }}/test/e2e/...
 

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 
 require (
 	github.com/hashicorp/hcl v1.0.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gotest.tools/v3 v3.0.3
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	knative.dev/client v0.30.2-0.20220329090315-1bab8209ceab
@@ -126,7 +127,6 @@ require (
 	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect

--- a/test/clients.go
+++ b/test/clients.go
@@ -29,9 +29,9 @@ const (
 	Namespace = "default"
 
 	// PollInterval is how frequently e2e tests will poll for updates.
-	PollInterval = 1 * time.Second
+	PollInterval = 5 * time.Second
 	// PollTimeout is how long e2e tests will wait for resource updates when polling.
-	PollTimeout = 1 * time.Minute
+	PollTimeout = 5 * time.Minute
 )
 
 type Clients struct {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
+
 	"github.com/vmware-tanzu/sources-for-knative/plugins/vsphere/pkg/command/root"
 
 	"github.com/davecgh/go-spew/spew"
@@ -169,7 +170,7 @@ func RunJobScript(t *testing.T, clients *test.Clients, image string, command []s
 	}
 }
 
-func RunJobListener(t *testing.T, clients *test.Clients) (string, context.CancelFunc, context.CancelFunc) {
+func RunJobListener(t *testing.T, clients *test.Clients, eventType, eventCount string) (string, context.CancelFunc, context.CancelFunc) {
 	ctx := context.Background()
 	name := helpers.ObjectNameForTest(t)
 
@@ -193,10 +194,20 @@ func RunJobListener(t *testing.T, clients *test.Clients) (string, context.Cancel
 							Name:          "http",
 							ContainerPort: 8080,
 						}},
-						Env: []corev1.EnvVar{{
-							Name:  "PORT",
-							Value: "8080",
-						}},
+						Env: []corev1.EnvVar{
+							{
+								Name:  "PORT",
+								Value: "8080",
+							},
+							{
+								Name:  "EVENT_COUNT",
+								Value: eventCount,
+							},
+							{
+								Name:  "EVENT_TYPE",
+								Value: eventType,
+							},
+						},
 						ReadinessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								TCPSocket: &corev1.TCPSocketAction{
@@ -232,6 +243,21 @@ func RunJobListener(t *testing.T, clients *test.Clients) (string, context.Cancel
 			t.Errorf("Error cleaning up pods for Job %s", job.Name)
 		}
 	}
+
+	// Wait for the Job to start
+	readyErr := wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
+		js, err := clients.KubeClient.BatchV1().Jobs(test.Namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+
+		// Check for successful completions.
+		return js.Status.Active > 0, nil
+	})
+	if readyErr != nil {
+		t.Fatalf("Error waiting for Job to start successfully: %v", readyErr)
+	}
+
 	waiter := func() {
 		// Wait for the Job to report a successful execution.
 		waitErr := wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
@@ -310,7 +336,7 @@ func CreateSource(t *testing.T, clients *test.Clients, name string) context.Canc
 	ctx := context.Background()
 	t.Helper()
 
-	//Set a checkpoint in the past in case test creates events before vsphere source is ready
+	// Set a checkpoint in the past in case test creates events before vsphere source is ready
 	checkpointTime := time.Now().Add(time.Minute * -9)
 	checkpointConfigmap, err := clients.KubeClient.CoreV1().ConfigMaps(ns).Create(
 		ctx,
@@ -320,7 +346,6 @@ func CreateSource(t *testing.T, clients *test.Clients, name string) context.Canc
 		},
 		metav1.CreateOptions{},
 	)
-
 	if err != nil {
 		t.Fatalf("Error creating Configmap: %v", err)
 	}
@@ -419,6 +444,23 @@ func CreateSimulator(t *testing.T, clients *test.Clients) context.CancelFunc {
 		if err != nil {
 			t.Errorf("Error cleaning up Secret %s", secret.Name)
 		}
+
+		waitErr := wait.PollImmediate(test.PollInterval, time.Minute, func() (bool, error) {
+			_, err = clients.KubeClient.AppsV1().Deployments(ns).Get(ctx, simDeployment.Name, metav1.GetOptions{})
+			if err != nil {
+				if apierrs.IsNotFound(err) {
+					return true, nil
+				}
+				return false, err
+			}
+			return true, nil
+		})
+
+		if waitErr != nil {
+			t.Fatalf("Error waiting for VCSIM deployment to be deleted: %v", waitErr)
+		}
+
+		t.Log("vcsim deleted")
 	}
 
 	waitErr := wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
@@ -452,7 +494,7 @@ func newSimulator(namespace, image string) (*appsv1.Deployment, *corev1.Service)
 	}
 	args := []string{"-l", ":8989"}
 	if image == defaultVcsimImage {
-		//vmware/vcsim image is built differently, it does not use ko. Therefore, the entrypoint is different.
+		// vmware/vcsim image is built differently, it does not use ko. Therefore, the entrypoint is different.
 		args = append([]string{"vcsim"}, args...)
 	}
 

--- a/test/test_images/listener/main.go
+++ b/test/test_images/listener/main.go
@@ -7,11 +7,14 @@ package main
 
 import (
 	"context"
-	"log"
-	"sync/atomic"
+	"errors"
+	"fmt"
 	"time"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
+	ce "github.com/cloudevents/sdk-go/v2"
+	"github.com/kelseyhightower/envconfig"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
 )
@@ -21,43 +24,96 @@ const (
 	ceVSphereEventClass = "eventclass"
 )
 
-func main() {
-	ctx := signals.NewContext()
+type envConfig struct {
+	ExpectedEventType  string `envconfig:"EVENT_TYPE" required:"true"`
+	ExpectedEventCount int    `envconfig:"EVENT_COUNT" required:"true"`
+}
 
-	client, err := cloudevents.NewClientHTTP()
-	if err != nil {
-		log.Fatal(err.Error())
+func main() {
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		panic("unable to read environment config: " + err.Error())
 	}
 
+	ctx := signals.NewContext()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Launch a go routine to avoid blocking
-	go func() {
-		timeout := 10 * time.Second
-		<-time.After(timeout)
-		logging.FromContext(ctx).Infow("cancelling context: timeout reached", "timeout", timeout)
-		cancel()
-	}()
+	logger := logging.FromContext(ctx)
 
-	var count int32
-	if err = client.StartReceiver(ctx, func(ctx context.Context, event cloudevents.Event) {
-		logging.FromContext(ctx).Infof("Received event: %s", event.String())
-		atomic.AddInt32(&count, 1)
-
-		// assert required CE extension attributes are always present
-		if event.Extensions()[ceVSphereEventClass] == "" {
-			logging.FromContext(ctx).Fatalf("CloudEvent extension %q not set", ceVSphereEventClass)
-		}
-		if event.Extensions()[ceVSphereAPIKey] == "" {
-			logging.FromContext(ctx).Fatalf("CloudEvent extension %q not set", ceVSphereAPIKey)
-		}
-	}); err != nil {
-		logging.FromContext(ctx).Fatalf("receiving events: %v", err)
+	numExpectedEvents := env.ExpectedEventCount
+	client, err := ce.NewClientHTTP()
+	if err != nil {
+		logger.Fatalw("could not create cloudevents client", zap.Error(err))
 	}
 
-	if count == 0 {
-		logging.FromContext(ctx).Fatalf("no events received")
+	eg, egCtx := errgroup.WithContext(ctx)
+	events := make(chan ce.Event, numExpectedEvents)
+
+	// cloudevents http receiver
+	eg.Go(func() error {
+		logger.Info("starting cloudevents listener")
+		// receive events, putting them into the channel only if they meet the type we are expecting
+		return client.StartReceiver(egCtx, func(event ce.Event) {
+			logger.Infow("received cloud event on listener", zap.String("event", event.String()))
+			if event.Type() == env.ExpectedEventType {
+				select {
+				case events <- event:
+				default:
+					logger.Warn("could not send on events channel")
+
+					// artificial throttle to not spam logs in case of hot loop
+					time.Sleep(time.Second)
+				}
+				return
+			}
+			logger.Warnw(
+				"ignoring event: unexpected event type received",
+				zap.String("received", event.Type()),
+				zap.String("expected", env.ExpectedEventType),
+			)
+		})
+	})
+
+	// thread-safe counter
+	eg.Go(func() error {
+		count := 0
+		// Process events one by one, keeping count. Exit when count is reached, and cancel the start receiver
+
+		for {
+			select {
+			case <-egCtx.Done():
+				return egCtx.Err()
+			case event := <-events:
+				logger.Infow("received event on events channel", zap.String("message", event.String()))
+
+				// assert required CE extension attributes are always present
+				class := event.Extensions()[ceVSphereEventClass]
+				if class == nil || class == "" {
+					return fmt.Errorf("cloudevent extension %q not set", ceVSphereEventClass)
+				}
+
+				apiKey := event.Extensions()[ceVSphereAPIKey]
+				if apiKey == nil || apiKey == "" {
+					return fmt.Errorf("cloudevent extension %q not set", ceVSphereAPIKey)
+				}
+
+				count++
+				if count == numExpectedEvents {
+					logger.Infow(
+						"cancelling context: received expected number of events",
+						zap.Int("expected", numExpectedEvents),
+						zap.Int("received", count),
+					)
+					cancel()
+					return nil
+				}
+			}
+		}
+	})
+
+	if err := eg.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+		logger.Fatalw("Could not successfully receive expected events", zap.Error(err))
 	}
-	logging.FromContext(ctx).Infow("successfully received event(s)", "count", count)
+	logger.Info("shutdown complete")
 }


### PR DESCRIPTION
## Why
Currently, in the source_test.go test, the listener used to verify events are sent only lives for 10 seconds, and then will exit as failed, then restart.

I believe this causes timing issues with this test, which leads to flakiness. Because the listener is failing/restarting every 10 seconds, there is increased chance that when the vspheresource attempts to send the events to the listener, there is nothing at the endpoint, and the events never make it to the listener. I want to adjust these tests to avoid this scenario.

## Proposed Changes

- :broom: Update or clean up current behavior
- this change makes the test more specific, and avoids timing problems
- the listener now expects events related to the actual job the test runs, namely, events signifying that the two vms indeed were turned off. Right now, it only checks on the type of the event 
- the listener no longer has a timeout. It will run until it receives the expected number of events. If it never receives them, the CancelFunc returned by RunJobListener will clean up the job+pod. By constantly being up, this will hopefully avoid timing issues that lead to flakes.


### Pre-review Checklist

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs** for any user-facing impact

**Release Note**
N/A
