### PR TITLE
Configurable logging levels in `VSphereSource`

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ All components follow Knative logging convention and use the
 level (`debug`, `info`, `error`,
 [etc.](https://github.com/uber-go/zap/blob/6f34060764b5ea1367eecda380ba8a9a0de3f0e6/zapcore/level.go#L138))
 is configurable per component, e.g. `vsphere-source-webhook`, `VSphereSource`
-`adapter`, etc.
+adapter, etc.
 
 The default logging level is `info`. The following sections describe how to
 change the individual component log levels.
@@ -444,25 +444,25 @@ vsphere-source-webhook-f7d8ffbc9-4xfwl vsphere-source-webhook {"level":"info","t
 
 ⚠️ **Note:** To avoid unwanted disruption during event retrieval/delivery, the
 changes are **not applied** automatically to deployed adapters, i.e.
-`VSphereSource` adapter, etc.
+`VSphereSource` adapter, etc. The operator is in full control over the lifecycle
+(downtime) of the affected `Deployment(s)`.
 
-To make the changes take affect for existing adapter `Deployments`, an operator
-needs to manually scale a particular adapter `Deployment` to `--replicas 0`. The
-`Source` controller will react to this change by creating a new instance (`Pod`)
-with the desired log level changes and setting `replicas` to the default count
-(`1`) again.
+To make the changes take affect for existing adapter `Deployment`, an operator
+needs to manually perform a rolling upgrade. The existing adapter `Pod` will be
+terminated and a new instanced created with the desired log level changes.
 
 ```
 kubectl get vspheresource
 NAME                SOURCE                     SINK                                                                              READY   REASON
 example-vc-source   https://my-vc.corp.local   http://broker-ingress.knative-eventing.svc.cluster.local/default/example-broker   True
 
-kubectl scale deployment --replicas 0 example-vc-source-deployment
-deployment.apps/example-vc-source-deployment scaled
+kubectl rollout restart deployment/example-vc-source-deployment
+deployment.apps/example-vc-source-deployment restarted
 ```
 
-⚠️ **Note:** To avoid losing events due to this (brief) downtime, use the
-[Checkpointing](#configuring-checkpoint-and-event-replay) capability.
+⚠️ **Note:** To avoid losing events due to this (brief) downtime, consider
+enabling the [Checkpointing](#configuring-checkpoint-and-event-replay)
+capability.
 
 ### `Controller` and `Webhook` Log Level
 

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -37,3 +37,4 @@ data:
   # For all components changes are be picked up immediately.
   loglevel.controller: "info"
   loglevel.webhook: "info"
+  loglevel.vsphere-source-webhook: "info"

--- a/pkg/reconciler/vspheresource/resources/deployment.go
+++ b/pkg/reconciler/vspheresource/resources/deployment.go
@@ -115,6 +115,9 @@ func MakeDeployment(ctx context.Context, vms *v1alpha1.VSphereSource, args Adapt
 				},
 			},
 			Strategy: appsv1.DeploymentStrategy{
+				// terminate existing instance before creating a new one to reduce chance of
+				// multiple source adapters sending events when changing log levels and running
+				// kubectl rollout restart
 				Type: appsv1.RecreateDeploymentStrategyType,
 			},
 		},

--- a/pkg/vsphere/adapter.go
+++ b/pkg/vsphere/adapter.go
@@ -178,13 +178,12 @@ func (a *vAdapter) readEvents(ctx context.Context, c *event.HistoryCollector) er
 			skip := lastEvent == nil || lastCheckpointEventKey == lastEvent.GetEvent().Key
 			if !skip {
 				var current checkpoint
-				err := a.KVStore.Get(ctx, checkpointKey, &current)
-				if err != nil {
+				if err := a.KVStore.Get(ctx, checkpointKey, &current); err != nil {
 					return fmt.Errorf("retrieve current checkpoint: %w", err)
 				}
 
 				logger.Debugw("creating checkpoint", zap.Any("checkpoint", current))
-				if err = a.KVStore.Save(ctx); err != nil {
+				if err := a.KVStore.Save(ctx); err != nil {
 					return fmt.Errorf("save checkpoint: %w", err)
 				}
 				lastCheckpointEventKey = lastEvent.GetEvent().Key

--- a/pkg/vsphere/adapter.go
+++ b/pkg/vsphere/adapter.go
@@ -128,9 +128,8 @@ func (a *vAdapter) Start(ctx context.Context) error {
 func (a *vAdapter) run(ctx context.Context) error {
 	var cp checkpoint
 	if err := a.KVStore.Get(ctx, checkpointKey, &cp); err != nil {
-		logging.FromContext(ctx).Warn("get last checkpoint: ", err)
+		logging.FromContext(ctx).Warnw("could not retrieve checkpoint configuration", zap.Error(err))
 	}
-
 	// begin of event stream defaults to current vCenter time (UTC)
 	vcTime, err := methods.GetCurrentTime(ctx, a.VClient)
 	if err != nil {
@@ -178,8 +177,14 @@ func (a *vAdapter) readEvents(ctx context.Context, c *event.HistoryCollector) er
 			// avoid unnecessary K8s API calls
 			skip := lastEvent == nil || lastCheckpointEventKey == lastEvent.GetEvent().Key
 			if !skip {
-				logger.Debug("creating checkpoint")
-				if err := a.KVStore.Save(ctx); err != nil {
+				var current checkpoint
+				err := a.KVStore.Get(ctx, checkpointKey, &current)
+				if err != nil {
+					return fmt.Errorf("retrieve current checkpoint: %w", err)
+				}
+
+				logger.Debugw("creating checkpoint", zap.Any("checkpoint", current))
+				if err = a.KVStore.Save(ctx); err != nil {
 					return fmt.Errorf("save checkpoint: %w", err)
 				}
 				lastCheckpointEventKey = lastEvent.GetEvent().Key
@@ -261,6 +266,12 @@ func (a *vAdapter) sendEvents(ctx context.Context, baseEvents []types.BaseEvent)
 		}
 
 		// TODO: better partial batch failure handling here?
+		logging.FromContext(ctx).Debugw("sending event",
+			zap.String("ID", ev.ID()),
+			zap.String("type", ev.Type()),
+			zap.Any("data", be),
+		)
+
 		result := a.CEClient.Send(ctx, ev)
 		if !cloudevents.IsACK(result) {
 			logging.FromContext(ctx).Errorw("failed to send cloudevent", zap.Error(result))


### PR DESCRIPTION
Fixes #343

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Logging and metrics can be changed at runtime for all vSphere components
- :broom: Enhance logging in certain vSphere adapter areas
- Describe how to change logging in README

Note: The implementation follows the dynamic logging/metrics configuration pattern used in [`rabbitmqsource`](https://github.com/knative-sandbox/eventing-rabbitmq/blob/07661b9d44f5933d0949f9a23781c84e8a2fc55b/pkg/reconciler/source/rabbitmqsource.go#L189)

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [x] **Docs** for any user-facing impact

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The logging level for the `VSphereSource` and `VSphereBinding` components, i.e. `vsphere-source-webhook` and `adapter` `Deployments`, can now be changed at runtime.
```
