### PR TITLE
DO NOT MERGE

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -87,5 +87,5 @@ jobs:
         # For logstream to work.
         export SYSTEM_NAMESPACE=vmware-sources
         # Run the tests tagged as e2e on the KinD cluster.
-        go test -v -race -timeout=3m -tags=e2e github.com/${{ github.repository }}/test/e2e/...
+        go test -v -race -timeout=10m -tags=e2e github.com/${{ github.repository }}/test/e2e/...
 

--- a/test/clients.go
+++ b/test/clients.go
@@ -29,9 +29,9 @@ const (
 	Namespace = "default"
 
 	// PollInterval is how frequently e2e tests will poll for updates.
-	PollInterval = 1 * time.Second
+	PollInterval = 5 * time.Second
 	// PollTimeout is how long e2e tests will wait for resource updates when polling.
-	PollTimeout = 1 * time.Minute
+	PollTimeout = 5 * time.Minute
 )
 
 type Clients struct {

--- a/test/e2e/source_test.go
+++ b/test/e2e/source_test.go
@@ -26,8 +26,11 @@ func TestSource(t *testing.T) {
 	cleanupVcsim := CreateSimulator(t, clients)
 	defer cleanupVcsim()
 
-	// Create a job/svc that listens for events and then quits N seconds after the first is received.
-	name, wait, cancelListener := RunJobListener(t, clients)
+	// Create a job/svc that listens for expectedCount of events of expectedType
+	// It will quit after meeting those criteria, or be cleaned up by cancelListener
+	expectedType := "com.vmware.vsphere.VmPoweredOffEvent.v0"
+	expectedCount := "2"
+	name, wait, cancelListener := RunJobListener(t, clients, expectedType, expectedCount)
 	defer cancelListener()
 
 	// Create a source that emits events from the vcsim.

--- a/test/e2e/source_test.go
+++ b/test/e2e/source_test.go
@@ -30,14 +30,17 @@ func TestSource(t *testing.T) {
 	// It will quit after meeting those criteria, or be cleaned up by cancelListener
 	expectedType := "com.vmware.vsphere.VmPoweredOffEvent.v0"
 	expectedCount := "2"
+
+	t.Log("creating event listener")
 	name, wait, cancelListener := RunJobListener(t, clients, expectedType, expectedCount)
 	defer cancelListener()
 
 	// Create a source that emits events from the vcsim.
+	t.Log("creating event source")
 	cancelSource := CreateSource(t, clients, name)
 	defer cancelSource()
 
-	// trigger events
+	t.Log("creating source binding")
 	selector, cancelTrigger := CreateJobBinding(t, clients)
 	defer cancelTrigger()
 
@@ -51,7 +54,8 @@ func TestSource(t *testing.T) {
 		"govc vm.power -off /DC0/vm/DC0_H0_VM1 && sleep 3",
 	}, "\n")
 
-	// Run a simple script as a Job on the cluster.
+	// Run a simple script as a Job on the cluster to trigger events
+	t.Log("creating job to trigger events")
 	RunBashJob(t, clients, pkgtest.ImagePath("govc"), script, selector)
 
 	// Wait for the job to complete, and then cleanup.

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -169,7 +169,7 @@ func RunJobScript(t *testing.T, clients *test.Clients, image string, command []s
 	}
 }
 
-func RunJobListener(t *testing.T, clients *test.Clients) (string, context.CancelFunc, context.CancelFunc) {
+func RunJobListener(t *testing.T, clients *test.Clients, eventType, eventCount string) (string, context.CancelFunc, context.CancelFunc) {
 	ctx := context.Background()
 	name := helpers.ObjectNameForTest(t)
 
@@ -193,10 +193,20 @@ func RunJobListener(t *testing.T, clients *test.Clients) (string, context.Cancel
 							Name:          "http",
 							ContainerPort: 8080,
 						}},
-						Env: []corev1.EnvVar{{
-							Name:  "PORT",
-							Value: "8080",
-						}},
+						Env: []corev1.EnvVar{
+							{
+								Name:  "PORT",
+								Value: "8080",
+							},
+							{
+								Name:  "EVENT_COUNT",
+								Value: eventCount,
+							},
+							{
+								Name:  "EVENT_TYPE",
+								Value: eventType,
+							},
+						},
 						ReadinessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								TCPSocket: &corev1.TCPSocketAction{

--- a/test/test_images/listener/main.go
+++ b/test/test_images/listener/main.go
@@ -65,6 +65,7 @@ func main() {
 			if err := xml.Unmarshal(event.Data(), eventData); err != nil {
 				logging.FromContext(ctx).Fatalf("Failed to unmarshal CloudEvent xml data: ", err)
 			}
+			logging.FromContext(ctx).Infof("Raw Message: %s", eventData.Message)
 		}
 
 		// assert required CE extension attributes are always present

--- a/test/test_images/listener/main.go
+++ b/test/test_images/listener/main.go
@@ -28,7 +28,7 @@ type envConfig struct {
 	ExpectedEventCount string `envconfig:"EVENT_COUNT"`
 }
 
-type VmPoweredOffEvent struct {
+type VMPoweredOffEvent struct {
 	XMLName xml.Name `xml:"VmPoweredOffEvent"`
 	Message string   `xml:"fullFormattedMessage"`
 }
@@ -61,7 +61,7 @@ func main() {
 		if event.Type() == env.ExpectedEventType {
 			atomic.AddInt32(&count, 1)
 
-			eventData := &VmPoweredOffEvent{}
+			eventData := &VMPoweredOffEvent{}
 			if err := xml.Unmarshal(event.Data(), eventData); err != nil {
 				logging.FromContext(ctx).Fatalf("Failed to unmarshal CloudEvent xml data: ", err)
 			}

--- a/test/test_images/listener/main.go
+++ b/test/test_images/listener/main.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/xml"
 	"log"
-	"strconv"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
@@ -24,7 +23,7 @@ const (
 
 type envConfig struct {
 	ExpectedEventType  string `envconfig:"EVENT_TYPE"`
-	ExpectedEventCount string `envconfig:"EVENT_COUNT"`
+	ExpectedEventCount int    `envconfig:"EVENT_COUNT"`
 }
 
 type VMPoweredOffEvent struct {
@@ -33,36 +32,35 @@ type VMPoweredOffEvent struct {
 }
 
 func main() {
-	ctx := signals.NewContext()
+	var env envConfig
+	if err := envconfig.Process("", &env); err != nil {
+		log.Fatalf("Unable to read environment config: %v", err)
+	}
+
+	numExpectedEvents := env.ExpectedEventCount
 
 	client, err := cloudevents.NewClientHTTP()
 	if err != nil {
 		log.Fatal(err.Error())
 	}
 
+	ctx := signals.NewContext()
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	var env envConfig
-	if err := envconfig.Process("", &env); err != nil {
-		log.Fatalf("Unable to read environment config: %v", err)
-	}
-
-	numExpectedEvents, err := strconv.Atoi(env.ExpectedEventCount)
-	if err != nil {
-		log.Fatalf("Invalid value for EVENT_COUNT (%v): %v", env.ExpectedEventCount, err)
-	}
+	log := logging.FromContext(ctx)
 
 	events := make(chan cloudevents.Event, numExpectedEvents)
 	// receive events, putting them into the channel only if they meet the type we are expecting
 	go func() {
 		if err = client.StartReceiver(ctx, func(event cloudevents.Event) {
-			logging.FromContext(ctx).Infof("Received event: %s", event.String())
+			log.Infof("Received event: %s", event.String())
 			if event.Type() == env.ExpectedEventType {
 				events <- event
 			}
 		}); err != nil {
-			logging.FromContext(ctx).Fatalf("receiving events: %v", err)
+			log.Fatalf("receiving events: %v", err)
 		}
 	}()
 
@@ -71,29 +69,26 @@ func main() {
 	for event := range events {
 		eventData := &VMPoweredOffEvent{}
 		if err := xml.Unmarshal(event.Data(), eventData); err != nil {
-			logging.FromContext(ctx).Fatalf("Failed to unmarshal CloudEvent xml data: ", err)
+			log.Fatalf("Failed to unmarshal CloudEvent xml data: ", err)
 		}
-		logging.FromContext(ctx).Infof("Raw Message: %s", eventData.Message)
+		log.Infof("Raw Message: %s", eventData.Message)
 
 		// assert required CE extension attributes are always present
 		if event.Extensions()[ceVSphereEventClass] == "" {
-			logging.FromContext(ctx).Fatalf("CloudEvent extension %q not set", ceVSphereEventClass)
+			log.Fatalf("CloudEvent extension %q not set", ceVSphereEventClass)
 		}
 		if event.Extensions()[ceVSphereAPIKey] == "" {
-			logging.FromContext(ctx).Fatalf("CloudEvent extension %q not set", ceVSphereAPIKey)
+			log.Fatalf("CloudEvent extension %q not set", ceVSphereAPIKey)
 		}
 
 		count += 1
-
 		if count == numExpectedEvents {
-			logging.FromContext(ctx).Infow("cancelling context: Received expected number of events")
+			log.Infow("cancelling context: Received expected number of events")
 			cancel()
 			break
 		}
+
 	}
 
-	if count == 0 {
-		logging.FromContext(ctx).Fatalf("no events received")
-	}
-	logging.FromContext(ctx).Infow("successfully received event(s)", "count", count)
+	log.Infow("successfully received event(s)", "count", count)
 }

--- a/test/test_images/listener/main.go
+++ b/test/test_images/listener/main.go
@@ -8,10 +8,14 @@ package main
 import (
 	"context"
 	"encoding/xml"
-	"log"
+	"errors"
+	"fmt"
+	"time"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
+	ce "github.com/cloudevents/sdk-go/v2"
 	"github.com/kelseyhightower/envconfig"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
 )
@@ -22,8 +26,8 @@ const (
 )
 
 type envConfig struct {
-	ExpectedEventType  string `envconfig:"EVENT_TYPE"`
-	ExpectedEventCount int    `envconfig:"EVENT_COUNT"`
+	ExpectedEventType  string `envconfig:"EVENT_TYPE" required:"true"`
+	ExpectedEventCount int    `envconfig:"EVENT_COUNT" required:"true"`
 }
 
 type VMPoweredOffEvent struct {
@@ -34,61 +38,88 @@ type VMPoweredOffEvent struct {
 func main() {
 	var env envConfig
 	if err := envconfig.Process("", &env); err != nil {
-		log.Fatalf("Unable to read environment config: %v", err)
-	}
-
-	numExpectedEvents := env.ExpectedEventCount
-
-	client, err := cloudevents.NewClientHTTP()
-	if err != nil {
-		log.Fatal(err.Error())
+		panic("unable to read environment config: " + err.Error())
 	}
 
 	ctx := signals.NewContext()
-
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	log := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx)
 
-	events := make(chan cloudevents.Event, numExpectedEvents)
-	// receive events, putting them into the channel only if they meet the type we are expecting
-	go func() {
-		if err = client.StartReceiver(ctx, func(event cloudevents.Event) {
-			log.Infof("Received event: %s", event.String())
-			if event.Type() == env.ExpectedEventType {
-				events <- event
-			}
-		}); err != nil {
-			log.Fatalf("receiving events: %v", err)
-		}
-	}()
-
-	count := 0
-	// Process events one by one, keeping count. Exit when count is reached, and cancel the start receiver
-	for event := range events {
-		eventData := &VMPoweredOffEvent{}
-		if err := xml.Unmarshal(event.Data(), eventData); err != nil {
-			log.Fatalf("Failed to unmarshal CloudEvent xml data: ", err)
-		}
-		log.Infof("Raw Message: %s", eventData.Message)
-
-		// assert required CE extension attributes are always present
-		if event.Extensions()[ceVSphereEventClass] == "" {
-			log.Fatalf("CloudEvent extension %q not set", ceVSphereEventClass)
-		}
-		if event.Extensions()[ceVSphereAPIKey] == "" {
-			log.Fatalf("CloudEvent extension %q not set", ceVSphereAPIKey)
-		}
-
-		count += 1
-		if count == numExpectedEvents {
-			log.Infow("cancelling context: Received expected number of events")
-			cancel()
-			break
-		}
-
+	numExpectedEvents := env.ExpectedEventCount
+	client, err := ce.NewClientHTTP()
+	if err != nil {
+		logger.Fatalw("could not create cloudevents client", zap.Error(err))
 	}
 
-	log.Infow("successfully received event(s)", "count", count)
+	eg, egCtx := errgroup.WithContext(ctx)
+	events := make(chan ce.Event, numExpectedEvents)
+
+	// cloudevents http receiver
+	eg.Go(func() error {
+		logger.Info("starting cloudevents listener")
+		// receive events, putting them into the channel only if they meet the type we are expecting
+		return client.StartReceiver(egCtx, func(event ce.Event) {
+			logger.Infow("received cloud event on listener", zap.String("event", event.String()))
+			if event.Type() == env.ExpectedEventType {
+				select {
+				case events <- event:
+				default:
+					logger.Warn("could not send on events channel")
+
+					// artificial throttle to not spam logs in case of hot loop
+					time.Sleep(time.Second)
+				}
+				return
+			}
+			logger.Warnw(
+				"ignoring event: unexpected event type received",
+				zap.String("received", event.Type()),
+				zap.String("expected", env.ExpectedEventType),
+			)
+		})
+	})
+
+	// thread-safe counter
+	eg.Go(func() error {
+		count := 0
+		// Process events one by one, keeping count. Exit when count is reached, and cancel the start receiver
+
+		for {
+			select {
+			case <-egCtx.Done():
+				return egCtx.Err()
+			case event := <-events:
+				logger.Infow("received event on events channel", zap.String("message", event.String()))
+
+				// assert required CE extension attributes are always present
+				class := event.Extensions()[ceVSphereEventClass]
+				if class == nil || class == "" {
+					return fmt.Errorf("cloudevent extension %q not set", ceVSphereEventClass)
+				}
+
+				apiKey := event.Extensions()[ceVSphereAPIKey]
+				if apiKey == nil || apiKey == "" {
+					return fmt.Errorf("cloudevent extension %q not set", ceVSphereAPIKey)
+				}
+
+				count++
+				if count == numExpectedEvents {
+					logger.Infow(
+						"cancelling context: received expected number of events",
+						zap.Int("expected", numExpectedEvents),
+						zap.Int("received", count),
+					)
+					cancel()
+					return nil
+				}
+			}
+		}
+	})
+
+	if err := eg.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+		logger.Fatalw("Could not successfully receive expected events", zap.Error(err))
+	}
+	logger.Info("shutdown complete")
 }


### PR DESCRIPTION
* before, the listener would time out fairly shortly, and expect any sort of event.
* this change makes the test more specific, and avoids timing problems
* the listener now expects events related to the actual job the test runs, namely, events signifying that the two vms indeed were turned off
* removed timeout on job
* The job will exit when the appropriate number of events has been received
* OR
* the cancel function returned by the create listener function will clean the job upFixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs** for any user-facing impact

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```
