### PR TITLE
chore: bump kind node image to v1.23.5

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -35,6 +35,8 @@ jobs:
       working-directory: ./src/github.com/${{ github.repository }}
       env:
         KIND_VERSION: v0.11.1
+        NODE_VERSION: v1.23.5
+        NODE_SHA: sha256:a69c29d3d502635369a5fe92d8e503c09581fcd406ba6598acc5d80ff5ba81b1
       run: |
         set -x
 
@@ -48,7 +50,9 @@ jobs:
         kind: Cluster
         nodes:
         - role: control-plane
+          image: kindest/node:${NODE_VERSION}@${NODE_SHA}
         - role: worker
+          image: kindest/node:${NODE_VERSION}@${NODE_SHA}
         EOF
 
         # Create a cluster!


### PR DESCRIPTION
Fixes #429

Recent E2E tests fail with:

```
2022-04-21T11:56:47.995634245Z stdout F {"level":"fatal","ts":"2022-04-21T11:56:47.993Z","logger":"vsphere-source-webhook","caller":"sharedmain/main.go:313","msg":"Version check failed","commit":"8479058","error":"kubernetes version \"1.21.1\" is not compatible, need at least \"1.22.0-0\"
```

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Bump and explicitly set `kind` `node` image to `v1.23.5` as required by most recent deps

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs** for any user-facing impact

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```
