### PR TITLE
Migrate to Github Container Registry (Packages) `ghcr.io`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,13 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17
+
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -30,30 +32,24 @@ jobs:
 
   ko-resolve:
     needs: cli
-    name: Release ko artifact
+    name: Release ko artifact and push to Github Container Registry
     runs-on: ubuntu-latest
-    env:
-      GOPATH: ${{ github.workspace }}
-      GO111MODULE: off
-      KO_DOCKER_REPO: docker.io/vmware
 
     steps:
     - name: Set up Go 1.17.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.17.x
 
-    - name: Setup ko
+    # will install latest ko version and default login/configure
+    # KO_DOCKER_REPO to ghcr.io
+    - name: Setup ko for ghcr.io
       uses: imjasonh/setup-ko@v0.4
     
-    - run: |
-        docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
-
-    - name: Check out code onto GOPATH
-      uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
-        path: ./src/github.com/${{ github.repository }}
 
     - name: Get Release URL
       id: get_release_url
@@ -62,10 +58,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
 
     - name: Build and Publish images, Produce release artifact.
-      working-directory: ./src/github.com/${{ github.repository }}
       run: |
-        export GO111MODULE=on
-        export GOFLAGS=-mod=vendor
         ko resolve --platform=all --tags $(basename "${{ github.ref }}" ) -BRf config/ > release.yaml
 
     - name: Upload Release Asset
@@ -75,6 +68,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.get_release_url.outputs.upload_url }}
-        asset_path: ./src/github.com/${{ github.repository }}/release.yaml
+        asset_path: ./release.yaml
         asset_name: release.yaml
         asset_content_type: text/plain


### PR DESCRIPTION
Fixes #351

Migrate from Docker Hub to Github Container Registry for release artifacts (`ko` container images and `kn` plugins). Tested in a forked test environment (https://github.com/embano1/sources-for-knative/actions/runs/2222052530). 

Note that a **100% validation was not possible** due to potential account/IAM restrictions which might apply in this org (compared to my test bed).

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Container images and `goreleaser` artifacts (`kn vsphere` plugin) are now released on Github Container Registry
- :broom: Removed `GOPATH` related settings (not needed anymore)
- :broom: Updated to latest `actions` for installing `go` and `checkout`

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs** for any user-facing impact

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
Container images and `goreleaser` artifacts (`kn vsphere` plugin) are now released on Github Container Registry (previously Docker Hub).
```
