### PR TITLE
use correct arg in vcsim image when using dockerhub image

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -495,7 +495,7 @@ func newSimulator(namespace, image string) (*appsv1.Deployment, *corev1.Service)
 	args := []string{"-l", ":8989"}
 	if image == defaultVcsimImage {
 		// vmware/vcsim image is built differently, it does not use ko. Therefore, the entrypoint is different.
-		args = append([]string{"vcsim"}, args...)
+		args = append([]string{"/vcsim"}, args...)
 	}
 
 	sim := appsv1.Deployment{


### PR DESCRIPTION
Fixes # N/A

I noticed this problem when trying to run the tests using the Dockerhub image (i.e. not using ko to build vcsim). I must have missed this when I made the original PR with that change, sorry!

You can just run it with building vcsim yourself and you don't have this problem, so I don't think this is major.

## Proposed Changes
- :bug: Bug Fix: The args for the container were wrong. We need `/vcsim` not `vcsim`. Currently, it fails with this error: 
```
docker: Error response from daemon: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "vcsim": executable file not found in $PATH: unknown.
```
- Note: if the dockerhub version of vcsim ever gets built in a different way, this will probably fail again. Not sure what we can do to be proactive of that though.

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs** for any user-facing impact

**Release Note**

```release-note
N/A
```
