### PR TITLE
Fix E2E tests when using upstream vcsim

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -32,13 +32,12 @@ import (
 )
 
 const (
-	vcsim             = "vcsim"
-	ns                = "default"
-	vsphereCreds      = "vsphere-credentials"
-	user              = "user"
-	password          = "password"
-	jobNameKey        = "job-name"
-	defaultVcsimImage = "vmware/vcsim:latest"
+	vcsim        = "vcsim"
+	ns           = "default"
+	vsphereCreds = "vsphere-credentials"
+	user         = "user"
+	password     = "password"
+	jobNameKey   = "job-name"
 )
 
 type envConfig struct {
@@ -492,11 +491,6 @@ func newSimulator(namespace, image string) (*appsv1.Deployment, *corev1.Service)
 	l := map[string]string{
 		"app": vcsim,
 	}
-	args := []string{"-l", ":8989"}
-	if image == defaultVcsimImage {
-		// vmware/vcsim image is built differently, it does not use ko. Therefore, the entrypoint is different.
-		args = append([]string{"/vcsim"}, args...)
-	}
 
 	sim := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -517,7 +511,7 @@ func newSimulator(namespace, image string) (*appsv1.Deployment, *corev1.Service)
 					Containers: []corev1.Container{{
 						Name:            vcsim,
 						Image:           image,
-						Args:            args,
+						Args:            []string{"-l", ":8989"},
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Ports: []corev1.ContainerPort{
 							{


### PR DESCRIPTION
Closes: #453
Signed-off-by: Michael Gasch <15986659+embano1@users.noreply.github.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: remove `default` `vcsim` container image logic in E2E since this is not needed with `latest` `vcsim` image anymore (in fact was broken too, but unnoticed due to E2E using `ko` by default)

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs** for any user-facing impact

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```
