### PR TITLE
Use concurrency setting in E2E

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: kind-e2e-tests-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   e2e:


### PR DESCRIPTION
Cancels in progress E2E runs when new commits are pushed to the **same** PR and provides a fallback for non-PR runs, e.g. `main` merges, scheduled runs, etc.

Signed-off-by: Michael Gasch <15986659+embano1@users.noreply.github.com>

Fixes #455

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-
-
-

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [ ] **At least 80% unit test coverage**
- [ ] **E2E tests** for any new behavior
- [ ] **Docs** for any user-facing impact

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note

```
