### PR TITLE
fix: source is valid and fully-qualified url

### DIFF
--- a/pkg/vsphere/adapter.go
+++ b/pkg/vsphere/adapter.go
@@ -73,7 +73,7 @@ func NewAdapter(ctx context.Context, processed adapter.EnvConfigAccessor, ceClie
 		logger.Fatalf("unable to create vSphere client: %v", err)
 	}
 
-	source := vClient.URL().Host
+	source := vClient.URL().String()
 	if source == "" {
 		logger.Fatal("unable to determine vSphere client source: empty host")
 	}


### PR DESCRIPTION
The source property of the adapter was set using the URL host field which is incomplete and confusing for users migrating from the VEBA project to Sources. This fix changes the source semantic to be a valid and fully-qualifed URL of the configured vCenter event source.

Fixes #523

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

<!-- Please categorize your changes:
- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Make `Source` valid and fully-qualified URL

### Pre-review Checklist

<!-- If these boxes are not checked, you will be asked to complete these requirements or explain why they do not apply to your PR. -->

- [x] **At least 80% unit test coverage**
- [x] **E2E tests** for any new behavior
- [ ] **Docs** for any user-facing impact

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release note is needed.
-->

```release-note
The CloudEvent `Source` attribute now is a valid fully-qualified URL of the configured vCenter event source instead of just `host:port`. This enables smooth transition from [VEBA](http://vmweventbroker.io) users as well as aligns closer with the CloudEvents specification of this attribute. Most users won't be impacted by this change, but it is a breaking change nonetheless since the field property semantics change. Users which have defined specific filters relying on the old behavior may need to change filter/parsing logic for this field.
```
